### PR TITLE
Fix startup crash when trying to load a mod where the namespace doesn't contain any "." characters.

### DIFF
--- a/Extensions/TypePrefix.cs
+++ b/Extensions/TypePrefix.cs
@@ -7,7 +7,11 @@ public static class TypePrefix
     public const char PrefixSplitChar = '-';
     public static string GetPrefix(this Type t)
     {
-        return t.Namespace == null ? "" : 
-            $"{t.Namespace[..t.Namespace.IndexOf('.')].ToUpperInvariant()}{PrefixSplitChar}";
+        if (t.Namespace == null)
+            return "";
+        var dotIndex = t.Namespace.IndexOf('.');
+        if (dotIndex == -1)
+            dotIndex = t.Namespace.Length;
+        return $"{t.Namespace[..dotIndex].ToUpperInvariant()}{PrefixSplitChar}";
     }
 }


### PR DESCRIPTION
Attempting to load a power in the namespace "Example" instead of something like "Example.Powers" crashes because `IndexOf()` returns -1. This fixes said issue.