### PR TITLE
Draft: Allow for CustomAncientModel to Define a Forced Spawn Condition

### DIFF
--- a/Abstracts/CustomAncientModel.cs
+++ b/Abstracts/CustomAncientModel.cs
@@ -20,11 +20,21 @@ public abstract class CustomAncientModel : AncientEventModel, ICustomModel
     }
 
     /// <summary>
-    /// Suggested to check act.ActNumber == 2 or 3
+    /// Suggested to check act.ActNumber == 2 or 3.
+    ///
+    /// If you are overriding ShouldForceSpawn, you should override this and return false.
     /// </summary>
     /// <param name="act"></param>
     /// <returns></returns>
     public virtual bool IsValidForAct(ActModel act) => true;
+    
+    /// <summary>
+    /// Suggested to leave this set to false unless you want to force a specific ancient to spawn during map generation. Messing with this can cause mod conflicts, please only use if it is 100% necessary for your mod to function.
+    /// </summary>
+    /// <param name="act"></param>
+    /// <param name="rngChosenAncient">The ancient that will have been chosen by the games rng.</param>
+    /// <returns></returns>
+    public virtual bool ShouldForceSpawn(ActModel act, AncientEventModel? rngChosenAncient) => false;
     
     protected abstract OptionPools MakeOptionPools { get; }
 

--- a/Patches/Content/ContentPatches.cs
+++ b/Patches/Content/ContentPatches.cs
@@ -4,6 +4,7 @@ using BaseLib.Utils;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Modding;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Rooms;
 
 namespace BaseLib.Patches.Content;
 
@@ -134,6 +135,22 @@ class ModelDbSharedPotionPoolsPatch
     }
 }
 
+[HarmonyPatch(typeof(ActModel), nameof(ActModel.GenerateRooms))]
+class ActModelGenerateRoomsPatch
+{
+    [HarmonyPostfix]
+    static void ForceAncientToSpawn(ActModel __instance)
+    {
+        var rooms = Traverse.Create(__instance).Field<RoomSet>("_rooms").Value;
+        var rngChosenAncient = rooms.Ancient;
+        var ancientToSpawn = CustomContentDictionary.CustomAncients.Find(a => a.ShouldForceSpawn(__instance, rngChosenAncient));
+
+        if (ancientToSpawn != null)
+        {
+            rooms.Ancient = ancientToSpawn;
+        }
+    }
+}
 /*
 class CardPoolPatch
 {


### PR DESCRIPTION
# Allow for CustomAncientModel to Define a Forced Spawn Condition

This should allow for mods to "replace" a specific ancient or force their custom ancient to spawn under specific conditions. Let me know if I need to add additional warnings.