### PR TITLE
add play audio files patch

### DIFF
--- a/Patches/Misc/PlayAudioFilesPatch.cs
+++ b/Patches/Misc/PlayAudioFilesPatch.cs
@@ -1,0 +1,25 @@
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Audio;
+using MegaCrit.Sts2.Core.TestSupport;
+
+namespace BaseLib.Patches.Misc;
+
+[HarmonyPatch(typeof(NAudioManager), nameof(NAudioManager.PlayOneShot), typeof(string), typeof(Dictionary<string, float>), typeof(float))]
+class EnergyCounterPatch {
+    static bool Prefix(string path, Dictionary<string, float> parameters, float volume, NAudioManager __instance) {
+        if (TestMode.IsOn) return true;
+        if (!path.StartsWith("res://")) return true;
+        AudioStream audioStream = GD.Load<AudioStream>(path);
+        if (audioStream is null) return true;
+        AudioStreamPlayer2D audioPlayer = new() {
+            Bus = "SFX",
+            VolumeDb = Mathf.LinearToDb(volume),
+            Stream = GD.Load<AudioStream>(path),
+        };
+        __instance.GetTree().Root.AddChild(audioPlayer);
+        audioPlayer.Finished += audioPlayer.QueueFree;
+        audioPlayer.Play();
+        return false;
+    }
+}


### PR DESCRIPTION
right now if you override CharacterModel.CharacterTransitionSfx with a path to a normal sound file it doesnt play

this patches NAudioManager.PlayOneShot to play sound files from res:// paths