### PR TITLE
ancient dialogues

### DIFF
--- a/Abstracts/CustomAncientModel.cs
+++ b/Abstracts/CustomAncientModel.cs
@@ -1,10 +1,10 @@
-﻿using BaseLib.Patches.Content;
+﻿using System.Text;
+using BaseLib.Patches.Content;
 using BaseLib.Utils;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Ancients;
 using MegaCrit.Sts2.Core.Events;
-using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Runs;
 
@@ -13,10 +13,12 @@ namespace BaseLib.Abstracts;
 public abstract class CustomAncientModel : AncientEventModel, ICustomModel
 {
     //Suggested overrides: ButtonColor, DialogueColor
+    private readonly bool _logDialogueLoad;
     
-    public CustomAncientModel(bool autoAdd = true)
+    public CustomAncientModel(bool autoAdd = true, bool logDialogueLoad = false)
     {
         if (autoAdd) CustomContentDictionary.AddAncient(this);
+        _logDialogueLoad = logDialogueLoad;
     }
 
     /// <summary>
@@ -104,84 +106,30 @@ public abstract class CustomAncientModel : AncientEventModel, ICustomModel
 
     /****************** Localization ******************/
     private string FirstVisit => $"{Id.Entry}.talk.firstvisitEver.0-0.ancient";
-    private string BaseLocKeyForId(string id) => $"{Id.Entry}.talk.{id}.";
-
-    private static string SfxPath(string dialogueLoc) =>
-        LocString.GetIfExists("ancients", dialogueLoc + ".sfx")?.GetRawText() ?? "";
     
     protected override AncientDialogueSet DefineDialogues()
     {
-        AncientDialogue firstVisit = new(SfxPath(FirstVisit));
+        StringBuilder? log = _logDialogueLoad ? new($"Prepping dialogue for ancient '{Id.Entry}'") : null;
+        string sfxPath;
+        AncientDialogue firstVisit = new(sfxPath = AncientDialogueUtil.SfxPath(FirstVisit));
+        log?.AppendLine($"First visit with sfx '{sfxPath}'");
 
         Dictionary<string, IReadOnlyList<AncientDialogue>> characterDialogues = [];
         
-        foreach (CharacterModel character in ModelDb.AllCharacters)
+        foreach (var character in ModelDb.AllCharacters)
         {
-            var baseKey = BaseLocKeyForId(character.Id.Entry);
-            characterDialogues[baseKey] = GetDialoguesForKey(baseKey);
+            var baseKey = AncientDialogueUtil.BaseLocKey(Id.Entry, character.Id.Entry);
+            characterDialogues[character.Id.Entry] = AncientDialogueUtil.GetDialoguesForKey("ancients", baseKey, log);
         }
         
-        return new AncientDialogueSet
+        var dialogueSet = new AncientDialogueSet
         {
             FirstVisitEverDialogue = firstVisit,
             CharacterDialogues = characterDialogues,
-            AgnosticDialogues = GetDialoguesForKey("ANY")
+            AgnosticDialogues = AncientDialogueUtil.GetDialoguesForKey("ancients", "ANY", log)
         };
-    }
-
-    private IReadOnlyList<AncientDialogue> GetDialoguesForKey(string baseKey)
-    {
-        List<AncientDialogue> dialogues = [];
-        
-        int index = 0;
-        while (DialogueExists(baseKey, index))
-        {
-            List<string> sfxPaths = [];
-
-            var line = ExistingLine(baseKey, index, sfxPaths.Count);
-
-            while (line != null)
-            {
-                sfxPaths.Add(SfxPath(line));
-                line = ExistingLine(baseKey, index, sfxPaths.Count);
-            }
-            
-            dialogues.Add(new AncientDialogue(sfxPaths.ToArray()));    
-            ++index;
-        }
-
-        return dialogues;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="baseKey">first section of key ending with a '.'</param>
-    /// <param name="index">index of conversation</param>
-    /// <returns></returns>
-    private static bool DialogueExists(string baseKey, int index)
-    {
-        return LocString.Exists("ancients", $"{baseKey}{index}-0.ancient") ||
-               LocString.Exists("ancients", $"{baseKey}{index}-0r.ancient") ||
-               LocString.Exists("ancients", $"{baseKey}{index}-0.char") ||
-               LocString.Exists("ancients", $"{baseKey}{index}-0r.char");
-    }
-
-    private static string? ExistingLine(string baseKey, int dialogueIndex, int lineIndex)
-    {
-        string locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}r.ancient";
-        if (LocString.Exists("ancients", locEntry)) return locEntry;
-        
-        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}r.char";
-        if (LocString.Exists("ancients", locEntry)) return locEntry;
-        
-        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}.ancient";
-        if (LocString.Exists("ancients", locEntry)) return locEntry;
-        
-        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}.char";
-        if (LocString.Exists("ancients", locEntry)) return locEntry;
-
-        return null;
+        if (log != null) MainFile.Logger.Info(log.ToString());
+        return dialogueSet;
     }
 }
 

--- a/BaseLib.csproj
+++ b/BaseLib.csproj
@@ -17,9 +17,9 @@
         <PackageId>Alchyr.Sts2.BaseLib</PackageId>
         <Title>BaseLib-StS2</Title>
         <Description>Mod for Slay the Spire 2 providing utilities and features for other mods.</Description>
-        <Version>0.1.2</Version>
+        <Version>0.1.3</Version>
         <Authors>Alchyr</Authors>
-        <PackageReleaseNotes>custom energy, character compatibility patches</PackageReleaseNotes>
+        <PackageReleaseNotes>add ancient dialogues</PackageReleaseNotes>
         <PackageTags>c#</PackageTags>
         <NoWarn>$(NoWarn);NU5128;MSB3270</NoWarn>
 
@@ -117,8 +117,30 @@
     <ItemGroup>
       <Folder Include="scenes\baselib\" />
     </ItemGroup>
+    
+    <Target Name="UpdateManifestVersion" BeforeTargets="BeforeBuild">
+        <PropertyGroup>
+            <ManifestPath>$(MSBuildProjectName).json</ManifestPath>
+        </PropertyGroup>
 
-    <Target Name="CopyToModsFolderOnBuild" AfterTargets="PostBuildEvent">
+        <PropertyGroup>
+            <OldContent>$([System.IO.File]::ReadAllText($(ManifestPath)))</OldContent>
+            <NewContent>$([System.Text.RegularExpressions.Regex]::Replace($(OldContent), '("version":\s*")[^"]*', '$1v$(Version)'))</NewContent>
+        </PropertyGroup>
+
+        <WriteLinesToFile
+                Condition="'$(OldContent)' != '$(NewContent)'"
+                File="$(ManifestPath)"
+                Lines="$(NewContent)"
+                Overwrite="true"
+                Encoding="UTF-8" />
+
+        <Message Condition="'$(OldContent)' != '$(NewContent)'"
+                 Text="Updated mod_manifest.json to version $(Version)"
+                 Importance="high" />
+    </Target>
+
+    <Target Name="CopyToModsFolderOnBuild" AfterTargets="AfterBuild">
         <Message Text="Copying .dll and manifest to mods folder." Importance="high" />
         <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(Sts2Path)/mods/$(MSBuildProjectName)/" />
         <Copy SourceFiles="$(MSBuildProjectName).json" DestinationFolder="$(Sts2Path)/mods/$(MSBuildProjectName)/" />
@@ -135,27 +157,5 @@
 
     <Target Name="GodotPublishSkipped" AfterTargets="Publish" Condition="'$(GodotPath)' == '' or !Exists('$(GodotPath)')">
         <Message Text="Skipping Godot .pck export because GodotPath is not configured." Importance="high"/>
-    </Target>
-
-    <Target Name="UpdateManifestVersion" BeforeTargets="Publish">
-      <PropertyGroup>
-        <ManifestPath>$(MSBuildProjectDirectory)\$(MSBuildProjectName).json</ManifestPath>
-      </PropertyGroup>
-
-      <PropertyGroup>
-        <OldContent>$([System.IO.File]::ReadAllText($(ManifestPath)))</OldContent>
-        <NewContent>$([System.Text.RegularExpressions.Regex]::Replace($(OldContent), '("version":\s*")[^"]*', '$1v$(Version)'))</NewContent>
-      </PropertyGroup>
-
-      <WriteLinesToFile
-        Condition="'$(OldContent)' != '$(NewContent)'"
-        File="$(ManifestPath)"
-        Lines="$(NewContent)"
-        Overwrite="true"
-        Encoding="UTF-8" />
-
-      <Message Condition="'$(OldContent)' != '$(NewContent)'"
-               Text="Updated mod_manifest.json to version $(Version)"
-               Importance="high" />
     </Target>
 </Project>

--- a/BaseLib.json
+++ b/BaseLib.json
@@ -3,7 +3,7 @@
   "name": "BaseLib",
   "author": "Alchyr",
   "description": "Modding utility for Slay the Spire 2",
-  "version": "v0.1.2",
+  "version": "v0.1.3",
   "has_pck": true,
   "has_dll": true,
   "dependencies": [],

--- a/Patches/Content/AddAncientDialogues.cs
+++ b/Patches/Content/AddAncientDialogues.cs
@@ -1,0 +1,33 @@
+﻿using BaseLib.Abstracts;
+using BaseLib.Utils;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Ancients;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Patches.Content;
+
+[HarmonyPatch(typeof(AncientDialogueSet), nameof(AncientDialogueSet.PopulateLocKeys))]
+class AddAncientDialogues
+{
+    [HarmonyPrefix]
+    static void AddCharacterDefinedInteractions(AncientDialogueSet __instance, string ancientEntry)
+    {
+        MainFile.Logger.Info($"Checking for additional interactions with {ancientEntry}");
+        var characterDialogues = __instance.CharacterDialogues;
+        
+        foreach (var character in ModelDb.AllCharacters)
+        {
+            if (character is not CustomCharacterModel) continue;
+            
+            var baseKey = AncientDialogueUtil.BaseLocKey(ancientEntry, character.Id.Entry);
+            var currentDialogues = characterDialogues.GetValueOrDefault(baseKey, []);
+            var newDialogues = AncientDialogueUtil.GetDialoguesForKey("ancients", baseKey);
+            
+            if (newDialogues.Count > 0)
+            {
+                characterDialogues[character.Id.Entry] = [..currentDialogues, ..newDialogues];
+                MainFile.Logger.Info($"Found {newDialogues.Count} additional dialogues for {ancientEntry} with {character.Id.Entry}, total {characterDialogues[character.Id.Entry].Count}");
+            }
+        }
+    }
+}

--- a/Utils/AncientDialogueUtil.cs
+++ b/Utils/AncientDialogueUtil.cs
@@ -1,0 +1,116 @@
+﻿using System.Text;
+using MegaCrit.Sts2.Core.Entities.Ancients;
+using MegaCrit.Sts2.Core.Localization;
+
+namespace BaseLib.Utils;
+
+public static class AncientDialogueUtil
+{
+    private const string ArchitectKey = "THE_ARCHITECT";
+    private const string AttackKey = "-attack";
+    private const string VisitIndexKey = "-visit";
+    
+    public static string SfxPath(string dialogueLoc) =>
+        LocString.GetIfExists("ancients", dialogueLoc + ".sfx")?.GetRawText() ?? "";
+    
+    public static string BaseLocKey(string ancientId, string charId) => $"{ancientId}.talk.{charId}.";
+    
+    /// <summary>
+    /// Generates a list of AncientDialogue (conversations) by checking for existing localization with a specified file and key.
+    /// </summary>
+    /// <param name="locTable">name of table to check for localization</param>
+    /// <param name="baseKey"></param>
+    /// <param name="log"></param>
+    /// <returns></returns>
+    public static List<AncientDialogue> GetDialoguesForKey(string locTable, string baseKey, StringBuilder? log = null)
+    {
+        log?.AppendLine($"Looking for dialogues for '{baseKey}' in {locTable}.json");
+        List<AncientDialogue> dialogues = [];
+        var isArchitect = baseKey.StartsWith(ArchitectKey);
+        
+        int index = 0, visitIndex = 0;
+        while (DialogueExists(locTable, baseKey, index))
+        {
+            log?.Append($"Found dialogue '{index}'");
+
+            if (isArchitect)
+            {
+                visitIndex = index;
+            }
+            else
+            {
+                visitIndex = index switch
+                {
+                    0 => 0,
+                    1 => 1,
+                    2 => 4,
+                    _ => visitIndex + 3
+                };
+            }
+            var indexLoc = LocString.GetIfExists(locTable, $"{baseKey}{index}{VisitIndexKey}");
+            //Directly use Parse; if it exists it must be defined correctly.
+            if (indexLoc != null) visitIndex = int.Parse(indexLoc.GetRawText());
+            
+            List<string> sfxPaths = [];
+
+            var line = ExistingLine(locTable, baseKey, index, sfxPaths.Count);
+
+            while (line != null)
+            {
+                sfxPaths.Add(SfxPath(line));
+                line = ExistingLine(locTable, baseKey, index, sfxPaths.Count);
+            }
+
+            log?.AppendLine($" with {sfxPaths.Count} lines");
+
+            var attackers = ArchitectAttackers.None;
+            if (isArchitect)
+            {
+                attackers = ArchitectAttackers.Architect;
+                var attackString = LocString.GetIfExists(locTable, $"{baseKey}{index}{AttackKey}");
+                if (Enum.TryParse(attackString?.GetRawText(), true, out ArchitectAttackers result)) attackers = result;
+            }
+            
+            dialogues.Add(new AncientDialogue(sfxPaths.ToArray())
+            {
+                VisitIndex = visitIndex,
+                EndAttackers = attackers
+            });
+            ++index;
+        }
+
+        return dialogues;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="locTable"></param>
+    /// <param name="baseKey">first section of key ending with a '.'</param>
+    /// <param name="index">index of conversation</param>
+    /// <returns></returns>
+    private static bool DialogueExists(string locTable, string baseKey, int index)
+    {
+        return LocString.Exists(locTable, $"{baseKey}{index}-0.ancient") ||
+               LocString.Exists(locTable, $"{baseKey}{index}-0r.ancient") ||
+               LocString.Exists(locTable, $"{baseKey}{index}-0.char") ||
+               LocString.Exists(locTable, $"{baseKey}{index}-0r.char");
+    }
+
+    private static string? ExistingLine(string locTable, string baseKey, int dialogueIndex, int lineIndex)
+    {
+        var locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}r.ancient";
+        if (LocString.Exists(locTable, locEntry)) return locEntry;
+        
+        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}r.char";
+        if (LocString.Exists(locTable, locEntry)) return locEntry;
+        
+        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}.ancient";
+        if (LocString.Exists(locTable, locEntry)) return locEntry;
+        
+        locEntry = $"{baseKey}{dialogueIndex}-{lineIndex}.char";
+        if (LocString.Exists(locTable, locEntry)) return locEntry;
+
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #21 

Add entries to `ancients.json` matching the format of other ancient conversations, with some additional entries that have extra functionality.

Example given character ID `MYMOD-MYCHAR`
```json
  "THE_ARCHITECT.talk.MYMOD-MYCHAR.0-0r.char": "I kill you",
  "THE_ARCHITECT.talk.MYMOD-MYCHAR.0-0r.next": "Continue",
  "THE_ARCHITECT.talk.MYMOD-MYCHAR.0-1r.ancient": "No",
  "THE_ARCHITECT.talk.MYMOD-MYCHAR.0-attack": "BOTH"
```
`attack` is used only for `THE_ARCHITECT` and will determine whether architect or both player and architect attack. See the values of the `ArchitectAttackers` enum.

Add an entry with `.sfx` to set a sound effect path.

```json
  "NEOW.talk.MYMOD-MYCHAR.0-0.ancient": "[sine]hey[/sine]",
  "NEOW.talk.MYMOD-MYCHAR.0-0.ancient.sfx": "event:/sfx/npcs/neow/neow_welcome"
```

Notes on ancient dialogues format:
`0-0r.char` - Conversation index 0, line index 0, r (optional) means repeating, `.char` or `.ancient` for who is speaking
`.next` - Prompt on button to continue conversation

Conversation index -> visit index:
Conversation 0 is on visit 0 (first visit)
Conversation 1 is on visit 1
Conversation 2 is on visit 4

For the Architect, all conversations are consecutive.

You can add `"ANCIENT.talk.MYMOD-MYCHAR.0-visit": "3",` to set a custom visit index for a dialogue.

Conversations after the first 3 will follow a pattern of increasing index by 3 (or 1 for architect).

Architect dialogue is required for a character.

When visit index is an exact match, it will be guaranteed. If number of visits is greater than the visit index and the conversation is repeating, it has a random chance of being reused.