### PR TITLE
Update config UI setup to use _optionContainer

### DIFF
--- a/Config/UI/NModConfigPopup.cs
+++ b/Config/UI/NModConfigPopup.cs
@@ -123,7 +123,7 @@ public partial class NModConfigPopup : NClickableControl
 
         try
         {
-            config.SetupConfigUI(_optionScrollContainer);
+            config.SetupConfigUI(_optionContainer);
             _currentConfig = config;
             config.ConfigChanged += OnConfigChanged;
             Show();


### PR DESCRIPTION
When viewing the configs of multiple mods in a row the configs overlap.