### PR TITLE
can't reselect the original option in config dropdowns

### DIFF
--- a/Config/UI/NConfigDropdown.cs
+++ b/Config/UI/NConfigDropdown.cs
@@ -57,6 +57,7 @@ public partial class NConfigDropdown : NSettingsDropdown
         
         CloseDropdown();
         _currentOptionLabel.SetTextAutoSize(configDropdownItem.Data.Text);
+        _currentDisplayIndex = configDropdownItem.DisplayIndex; 
         configDropdownItem.Data.OnSet();
     }
 }


### PR DESCRIPTION
For the dropdown options in a mod config once you select a different option from the initial one you can't select that one again as `_currentDisplayIndex` doesn't get updated.