### PR TITLE
Allow the use of Godot's animation system to create character animations

### DIFF
--- a/Patches/Content/CustomAnimationPatch.cs
+++ b/Patches/Content/CustomAnimationPatch.cs
@@ -5,6 +5,7 @@ using MegaCrit.Sts2.Core.Nodes.Combat;
 
 namespace BaseLib.Patches.Content
 {
+    [HarmonyPatch(typeof(NCreature), nameof(NCreature.SetAnimationTrigger))]
     class CustomAnimationPatch
     {
         [HarmonyPrefix]


### PR DESCRIPTION
Let the character animation interface with the built-in animation machine of Godot, because for small and medium-sized mods, Spine is too heavy.
A more realistic situation is that currently, to achieve what a frame animation can do, one has to use Spine; otherwise, static images or other very complicated methods have to be employed to create animations. This doesn't feel very user-friendly.