### PR TITLE
fix: Prevent player-applied self-debuffs from overstaying due to SkipNextDurationTick

### DIFF
--- a/Patches/Features/SelfApplyDebuffPatch.cs
+++ b/Patches/Features/SelfApplyDebuffPatch.cs
@@ -1,0 +1,36 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Entities.Powers;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Patches.Features;
+
+/// <summary>
+/// If player apply debuff to self or ally before turn ends (not from curse cards like doubt),
+/// the debuff should tick it's duration at enemy's turn ends
+/// </summary>
+[HarmonyPatch(typeof(PowerCmd), nameof(PowerCmd.Apply), [typeof(PowerModel), typeof(Creature), typeof(decimal), typeof(Creature), typeof(CardModel), typeof(bool)])]
+public static class SelfApplyDebuffPatch
+{
+    [HarmonyPostfix]
+    static void Postfix(ref Task __result, PowerModel power, Creature target)
+    {
+        // Replace the original Task with our wrapped Task
+        __result = WrappedApplyTask(__result, power, target);
+    }
+
+    static async Task WrappedApplyTask(Task originalTask, PowerModel power, Creature target)
+    {
+        // First, wait for all await methods in the original function (including Hook.AfterPowerAmountChanged, etc.) to complete execution.
+        await originalTask;
+
+        // At this point, all the logic in the original function has been executed, including the part that sets SkipNextDurationTick to true.
+        if (target.Side == CombatSide.Player && power.Type == PowerType.Debuff && power.Applier?.Side == CombatSide.Player)
+        {
+            // Ensure player-applied debuffs on self/allies tick at current (enemy's) turn end
+            power.SkipNextDurationTick = false;
+        }
+    }
+}


### PR DESCRIPTION
## Original Design in STS2
In the base game logic of `PowerCmd.Apply`, any Debuff applied to a player-side entity is automatically set to skip its next tick:
```cs
if (target.Side == CombatSide.Player && power.Type == PowerType.Debuff)
{
    power.SkipNextDurationTick = true;
}
```
This is likely designed to ensure that debuffs applied by enemies are not immediately reduced at the end of the current turn cycle, which would make 1-layer debuffs useless.

## The Issue
When a player applies a debuff to themselves or an ally (common in modded risk-reward cards), this same logic applies. This causes the self-inflicted debuff to persist for an extra cycle because it skips the first natural decay point at the current (enemy's) turn end.

## My Fix
This Patch ensures that if the Applier is on the player side, SkipNextDurationTick is set to false. This allows the debuff to follow the standard decay flow and decrease by 1 layer at the end of the current turn cycle, matching the player's strategic expectation.