### PR TITLE
Added ModAudio 

### DIFF
--- a/Abstracts/CustomCharacterModel.cs
+++ b/Abstracts/CustomCharacterModel.cs
@@ -54,7 +54,7 @@ public abstract class CustomCharacterModel : CharacterModel, ICustomModel
     /// <see cref="ModAudioHub"/> resolves <c>audio/sfx/...</c> and <c>audio/bgm/...</c> under this path.
     /// Override in your character model, or call <see cref="ModAudioHub.Register"/> directly. Return null to opt out.
     /// </summary>
-    public virtual string? ModAudioPath => null;
+    public virtual string? CustomAudioPath => null;
 
     //Defaults
     public override int StartingGold => 99;

--- a/Abstracts/CustomCharacterModel.cs
+++ b/Abstracts/CustomCharacterModel.cs
@@ -52,7 +52,7 @@ public abstract class CustomCharacterModel : CharacterModel, ICustomModel
 
     /// <summary>
     /// Godot path to this mod's <c>audio</c> folder — the folder that directly contains <c>sfx</c> and <c>bgm</c>
-    /// (e.g. <c>res://ThePaladin/audio</c>). Then use <see cref="ModAudio.PlaySfx"/>, <see cref="ModAudio.PlayMusic"/>, etc.
+    /// (e.g. <c>res://TheCharacter/audio</c>). Then use <see cref="ModAudio.PlaySfx"/>, <see cref="ModAudio.PlayMusic"/>, etc.
     /// Optional: <see cref="ModAudio.SetRoot"/> overrides; <see cref="ModAudio.Register"/> for id-based calls.
     /// </summary>
     public virtual string? CustomAudioPath => null;

--- a/Abstracts/CustomCharacterModel.cs
+++ b/Abstracts/CustomCharacterModel.cs
@@ -19,6 +19,7 @@ public abstract class CustomCharacterModel : CharacterModel, ICustomModel
     public CustomCharacterModel()
     {
         ModelDbCustomCharacters.Register(this);
+        ModAudio.NotifyCharacterConstructed(this);
     }
 
     /// <summary>
@@ -50,9 +51,9 @@ public abstract class CustomCharacterModel : CharacterModel, ICustomModel
     public virtual string? CustomDeathSfx => null;
 
     /// <summary>
-    /// Godot resource root for this mod's packaged audio (e.g. <c>res://mods/my_character</c>).
-    /// <see cref="ModAudioHub"/> resolves <c>audio/sfx/...</c> and <c>audio/bgm/...</c> under this path.
-    /// Override in your character model, or call <see cref="ModAudioHub.Register"/> directly. Return null to opt out.
+    /// Godot path to this mod's <c>audio</c> folder — the folder that directly contains <c>sfx</c> and <c>bgm</c>
+    /// (e.g. <c>res://ThePaladin/audio</c>). Then use <see cref="ModAudio.PlaySfx"/>, <see cref="ModAudio.PlayMusic"/>, etc.
+    /// Optional: <see cref="ModAudio.SetRoot"/> overrides; <see cref="ModAudio.Register"/> for id-based calls.
     /// </summary>
     public virtual string? CustomAudioPath => null;
 

--- a/Abstracts/CustomCharacterModel.cs
+++ b/Abstracts/CustomCharacterModel.cs
@@ -49,6 +49,13 @@ public abstract class CustomCharacterModel : CharacterModel, ICustomModel
     public virtual string? CustomCastSfx => null;
     public virtual string? CustomDeathSfx => null;
 
+    /// <summary>
+    /// Godot resource root for this mod's packaged audio (e.g. <c>res://mods/my_character</c>).
+    /// <see cref="ModAudioHub"/> resolves <c>audio/sfx/...</c> and <c>audio/bgm/...</c> under this path.
+    /// Override in your character model, or call <see cref="ModAudioHub.Register"/> directly. Return null to opt out.
+    /// </summary>
+    public virtual string? ModAudioPath => null;
+
     //Defaults
     public override int StartingGold => 99;
     public override float AttackAnimDelay => 0.15f;

--- a/Utils/ModAudio.cs
+++ b/Utils/ModAudio.cs
@@ -1,24 +1,28 @@
 using System.Collections.Generic;
 using System.Reflection;
+using BaseLib.Abstracts;
 using Godot;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Nodes;
 using MegaCrit.Sts2.Core.Nodes.Rooms;
 using MegaCrit.Sts2.Core.Random;
 using MegaCrit.Sts2.Core.Saves;
-using BaseLib.Abstracts;
 
 namespace BaseLib.Utils;
 
 /// <summary>
-/// Central audio helper for mods depending on BaseLib. Resolves streams under each
-/// character's <see cref="CustomCharacterModel.CustomAudioPath"/> (mod res root).
+/// OGG audio: set <see cref="CustomCharacterModel.CustomAudioPath"/> to your Godot <c>audio</c> folder (the one that
+/// contains <c>sfx</c> and <c>bgm</c>), then e.g. <c>ModAudio.PlaySfx("clip", vol)</c>.
+/// Layout: <c>{audioRoot}/sfx/...</c> and <c>{audioRoot}/bgm/...</c>.
 /// </summary>
-public static class ModAudioHub
+public static class ModAudio
 {
     private static readonly Dictionary<string, AudioStream> CachedStreams = new();
     private static readonly Dictionary<string, string> CharacterIdToRoot = new();
+    private static readonly HashSet<string> DistinctCustomAudioRoots = new(StringComparer.Ordinal);
+    private static string? _implicitRootFromCharacters;
     private static bool _discovered;
+    private static string? _defaultAudioRoot;
 
     private static AudioStreamPlayer? _musicPlayer;
     private static string? _currentMusicPath;
@@ -34,7 +38,27 @@ public static class ModAudioHub
     private const float AmbienceVolumeOffset = -6f;
     private const float SfxVolumeOffset = -3f;
 
+    /// <summary>Optional override: same as <see cref="CustomCharacterModel.CustomAudioPath"/> — path to the <c>audio</c> folder (with <c>sfx</c> / <c>bgm</c> inside).</summary>
+    public static void SetRoot(string? resRoot)
+    {
+        _defaultAudioRoot = string.IsNullOrWhiteSpace(resRoot) ? null : resRoot.TrimEnd('/');
+    }
 
+    /// <summary>Effective root: <see cref="SetRoot"/> if set, else inferred from character(s).</summary>
+    public static string? DefaultAudioRoot => _defaultAudioRoot ?? _implicitRootFromCharacters;
+
+    internal static void NotifyCharacterConstructed(CustomCharacterModel model)
+    {
+        var p = model.CustomAudioPath?.TrimEnd('/');
+        if (string.IsNullOrEmpty(p))
+            return;
+        DistinctCustomAudioRoots.Add(p);
+        _implicitRootFromCharacters = DistinctCustomAudioRoots.Count == 1 ? p : null;
+    }
+
+    /// <summary>Manual id → audio root mapping for <c>ModAudio.Play(characterId, ...)</c> overloads.</summary>
+    /// <param name="characterId">Character id string (e.g. placeholder id).</param>
+    /// <param name="modAudioResRoot">Path to the <c>audio</c> folder (contains <c>sfx</c> and <c>bgm</c>).</param>
     public static void Register(string characterId, string modAudioResRoot)
     {
         if (string.IsNullOrWhiteSpace(characterId) || string.IsNullOrWhiteSpace(modAudioResRoot))
@@ -43,8 +67,8 @@ public static class ModAudioHub
     }
 
     /// <summary>
-    /// Scans loaded assemblies for concrete <see cref="PlaceholderCharacterModel"/> types,
-    /// instantiates them, and registers non-empty <see cref="CustomCharacterModel.CustomAudioPath"/>.
+    /// Scans assemblies for concrete <see cref="PlaceholderCharacterModel"/> types and registers their
+    /// <see cref="CustomCharacterModel.CustomAudioPath"/> (for id-based overloads).
     /// </summary>
     public static void DiscoverPlaceholderCharacters()
     {
@@ -104,13 +128,15 @@ public static class ModAudioHub
         DiscoverPlaceholderCharacters();
     }
 
-    private static bool TryResolveRoot(string characterId, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
+    private static bool TryResolveRoot(string characterId,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
     {
         EnsureDiscovered();
         return CharacterIdToRoot.TryGetValue(characterId, out root);
     }
 
-    private static bool TryResolveRoot(CustomCharacterModel? model, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
+    private static bool TryResolveRoot(CustomCharacterModel? model,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
     {
         root = model?.CustomAudioPath?.TrimEnd('/');
         if (!string.IsNullOrEmpty(root))
@@ -124,8 +150,38 @@ public static class ModAudioHub
         return false;
     }
 
-    public static void Play(string characterId, string folder, string soundName, float volume = 0f, float pitchVariation = 0f,
-        float basePitch = 1f)
+    private static bool TryResolveDefaultRoot([System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
+    {
+        root = _defaultAudioRoot;
+        if (!string.IsNullOrEmpty(root))
+            return true;
+
+        root = _implicitRootFromCharacters;
+        if (!string.IsNullOrEmpty(root))
+            return true;
+
+        EnsureDiscovered();
+        root = _implicitRootFromCharacters;
+        if (!string.IsNullOrEmpty(root))
+            return true;
+
+        if (CharacterIdToRoot.Count == 0)
+            return false;
+
+        string? uniform = null;
+        foreach (var v in CharacterIdToRoot.Values)
+        {
+            uniform ??= v;
+            if (uniform != v)
+                return false;
+        }
+
+        root = uniform!;
+        return true;
+    }
+
+    public static void Play(string characterId, string folder, string soundName, float volume = 0f,
+        float pitchVariation = 0f, float basePitch = 1f)
     {
         if (!TryResolveRoot(characterId, out var modRoot))
             return;
@@ -136,6 +192,15 @@ public static class ModAudioHub
         float pitchVariation = 0f, float basePitch = 1f)
     {
         if (!TryResolveRoot(model, out var modRoot))
+            return;
+        PlayFromRoot(modRoot, folder, soundName, volume, pitchVariation, basePitch);
+    }
+
+    /// <summary>Combat SFX using <see cref="SetRoot"/> or your character's <see cref="CustomCharacterModel.CustomAudioPath"/>.</summary>
+    public static void Play(string folder, string soundName, float volume = 0f, float pitchVariation = 0f,
+        float basePitch = 1f)
+    {
+        if (!TryResolveDefaultRoot(out var modRoot))
             return;
         PlayFromRoot(modRoot, folder, soundName, volume, pitchVariation, basePitch);
     }
@@ -166,12 +231,20 @@ public static class ModAudioHub
         }
     }
 
-    /// <summary>Legacy-style call: creature parameter ignored (same as per-mod ModAudio).</summary>
+    /// <summary>Creature + character id (legacy); creature ignored.</summary>
     public static void Play(Creature creature, string characterId, string folder, string soundName, float volume = 0f) =>
         Play(characterId, folder, soundName, volume);
 
+    /// <summary>Creature ignored; uses resolved mod audio root.</summary>
+    public static void Play(Creature creature, string folder, string soundName, float volume = 0f) =>
+        Play(folder, soundName, volume);
+
     public static void PlaySfx(string characterId, string soundName, float volume = 0f, float pitchVariation = 0f) =>
         Play(characterId, "", soundName, volume, pitchVariation);
+
+    /// <summary><c>{audioRoot}/sfx/{soundName}.ogg</c> — see <see cref="CustomCharacterModel.CustomAudioPath"/> / <see cref="SetRoot"/>.</summary>
+    public static void PlaySfx(string soundName, float volume = 0f, float pitchVariation = 0f) =>
+        Play("", soundName, volume, pitchVariation);
 
     public static void PlayGlobalSfx(string characterId, string soundName, float volume = 0f)
     {
@@ -183,6 +256,13 @@ public static class ModAudioHub
     public static void PlayGlobalSfx(CustomCharacterModel model, string soundName, float volume = 0f)
     {
         if (!TryResolveRoot(model, out var modRoot))
+            return;
+        PlayGlobalSfxFromRoot(modRoot, soundName, volume);
+    }
+
+    public static void PlayGlobalSfx(string soundName, float volume = 0f)
+    {
+        if (!TryResolveDefaultRoot(out var modRoot))
             return;
         PlayGlobalSfxFromRoot(modRoot, soundName, volume);
     }
@@ -217,8 +297,8 @@ public static class ModAudioHub
             return cached;
 
         var path = string.IsNullOrEmpty(folder)
-            ? $"{modRoot}/audio/sfx/{soundName}.ogg"
-            : $"{modRoot}/audio/sfx/{folder}/{soundName}.ogg";
+            ? $"{modRoot}/sfx/{soundName}.ogg"
+            : $"{modRoot}/sfx/{folder}/{soundName}.ogg";
         var stream = GD.Load<AudioStream>(path);
         if (stream != null)
             CachedStreams[key] = stream;
@@ -232,9 +312,22 @@ public static class ModAudioHub
             return;
         if (!TryResolveRoot(characterId, out var modRoot))
             return;
+        PlayMusicAtRoot(modRoot, musicOptions, volumeDbOffset);
+    }
 
+    public static void PlayMusic(string[] musicOptions, float volumeDbOffset = 0f)
+    {
+        if (musicOptions == null || musicOptions.Length == 0)
+            return;
+        if (!TryResolveDefaultRoot(out var modRoot))
+            return;
+        PlayMusicAtRoot(modRoot, musicOptions, volumeDbOffset);
+    }
+
+    private static void PlayMusicAtRoot(string modRoot, string[] musicOptions, float volumeDbOffset)
+    {
         var musicName = musicOptions[GD.RandRange(0, musicOptions.Length - 1)];
-        var path = $"{modRoot}/audio/bgm/{musicName}.ogg";
+        var path = $"{modRoot}/bgm/{musicName}.ogg";
 
         if (_currentMusicPath == path && _musicPlayer?.Playing == true)
             return;
@@ -273,15 +366,29 @@ public static class ModAudioHub
             _musicPlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(volume, 2f)) + _currentVolumeOffset + MusicVolumeOffset;
     }
 
-    public static void FadeIn(string characterId, string[] musicOptions, float duration = 1.0f, float volumeDbOffset = 0f)
+    public static void FadeIn(string characterId, string[] musicOptions, float duration = 1.0f,
+        float volumeDbOffset = 0f)
     {
         if (musicOptions == null || musicOptions.Length == 0)
             return;
         if (!TryResolveRoot(characterId, out var modRoot))
             return;
+        FadeInAtRoot(modRoot, musicOptions, duration, volumeDbOffset);
+    }
 
+    public static void FadeIn(string[] musicOptions, float duration = 1.0f, float volumeDbOffset = 0f)
+    {
+        if (musicOptions == null || musicOptions.Length == 0)
+            return;
+        if (!TryResolveDefaultRoot(out var modRoot))
+            return;
+        FadeInAtRoot(modRoot, musicOptions, duration, volumeDbOffset);
+    }
+
+    private static void FadeInAtRoot(string modRoot, string[] musicOptions, float duration, float volumeDbOffset)
+    {
         var musicName = musicOptions[GD.RandRange(0, musicOptions.Length - 1)];
-        var path = $"{modRoot}/audio/bgm/{musicName}.ogg";
+        var path = $"{modRoot}/bgm/{musicName}.ogg";
 
         if (_currentMusicPath == path && _musicPlayer?.Playing == true)
             return;
@@ -384,8 +491,19 @@ public static class ModAudioHub
     {
         if (!TryResolveRoot(characterId, out var modRoot))
             return;
+        PlayAmbienceAtRoot(modRoot, ambienceName, volumeDbOffset);
+    }
 
-        var path = $"{modRoot}/audio/bgm/{ambienceName}.ogg";
+    public static void PlayAmbience(string ambienceName, float volumeDbOffset = 0f)
+    {
+        if (!TryResolveDefaultRoot(out var modRoot))
+            return;
+        PlayAmbienceAtRoot(modRoot, ambienceName, volumeDbOffset);
+    }
+
+    private static void PlayAmbienceAtRoot(string modRoot, string ambienceName, float volumeDbOffset)
+    {
+        var path = $"{modRoot}/bgm/{ambienceName}.ogg";
 
         if (_currentAmbiencePath == path && _ambiencePlayer?.Playing == true)
             return;
@@ -406,7 +524,8 @@ public static class ModAudioHub
         };
 
         var ambienceVolume = SaveManager.Instance.SettingsSave.VolumeAmbience;
-        _ambiencePlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(ambienceVolume, 2f)) + volumeDbOffset + AmbienceVolumeOffset;
+        _ambiencePlayer.VolumeDb =
+            Mathf.LinearToDb(Mathf.Pow(ambienceVolume, 2f)) + volumeDbOffset + AmbienceVolumeOffset;
 
         var runNode = NRun.Instance;
         if (runNode != null)
@@ -422,8 +541,19 @@ public static class ModAudioHub
     {
         if (!TryResolveRoot(characterId, out var modRoot))
             return;
+        FadeInAmbienceAtRoot(modRoot, ambienceName, duration, volumeDbOffset);
+    }
 
-        var path = $"{modRoot}/audio/bgm/{ambienceName}.ogg";
+    public static void FadeInAmbience(string ambienceName, float duration = 1.0f, float volumeDbOffset = 0f)
+    {
+        if (!TryResolveDefaultRoot(out var modRoot))
+            return;
+        FadeInAmbienceAtRoot(modRoot, ambienceName, duration, volumeDbOffset);
+    }
+
+    private static void FadeInAmbienceAtRoot(string modRoot, string ambienceName, float duration, float volumeDbOffset)
+    {
+        var path = $"{modRoot}/bgm/{ambienceName}.ogg";
 
         if (_currentAmbiencePath == path && _ambiencePlayer?.Playing == true)
             return;

--- a/Utils/ModAudioHub.cs
+++ b/Utils/ModAudioHub.cs
@@ -12,7 +12,7 @@ namespace BaseLib.Utils;
 
 /// <summary>
 /// Central audio helper for mods depending on BaseLib. Resolves streams under each
-/// character's <see cref="CustomCharacterModel.ModAudioPath"/> (mod res root).
+/// character's <see cref="CustomCharacterModel.CustomAudioPath"/> (mod res root).
 /// </summary>
 public static class ModAudioHub
 {
@@ -44,7 +44,7 @@ public static class ModAudioHub
 
     /// <summary>
     /// Scans loaded assemblies for concrete <see cref="PlaceholderCharacterModel"/> types,
-    /// instantiates them, and registers non-empty <see cref="CustomCharacterModel.ModAudioPath"/>.
+    /// instantiates them, and registers non-empty <see cref="CustomCharacterModel.CustomAudioPath"/>.
     /// </summary>
     public static void DiscoverPlaceholderCharacters()
     {
@@ -83,7 +83,7 @@ public static class ModAudioHub
                 if (instance == null)
                     continue;
 
-                var root = instance.ModAudioPath;
+                var root = instance.CustomAudioPath;
                 if (string.IsNullOrWhiteSpace(root))
                     continue;
 
@@ -112,7 +112,7 @@ public static class ModAudioHub
 
     private static bool TryResolveRoot(CustomCharacterModel? model, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
     {
-        root = model?.ModAudioPath?.TrimEnd('/');
+        root = model?.CustomAudioPath?.TrimEnd('/');
         if (!string.IsNullOrEmpty(root))
             return true;
 

--- a/Utils/ModAudioHub.cs
+++ b/Utils/ModAudioHub.cs
@@ -1,0 +1,496 @@
+using System.Collections.Generic;
+using System.Reflection;
+using Godot;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Nodes;
+using MegaCrit.Sts2.Core.Nodes.Rooms;
+using MegaCrit.Sts2.Core.Random;
+using MegaCrit.Sts2.Core.Saves;
+using BaseLib.Abstracts;
+
+namespace BaseLib.Utils;
+
+/// <summary>
+/// Central audio helper for mods depending on BaseLib. Resolves streams under each
+/// character's <see cref="CustomCharacterModel.ModAudioPath"/> (mod res root).
+/// </summary>
+public static class ModAudioHub
+{
+    private static readonly Dictionary<string, AudioStream> CachedStreams = new();
+    private static readonly Dictionary<string, string> CharacterIdToRoot = new();
+    private static bool _discovered;
+
+    private static AudioStreamPlayer? _musicPlayer;
+    private static string? _currentMusicPath;
+    private static float _currentVolumeOffset;
+    private static Tween? _fadeTween;
+    private static AudioStreamPlayer? _outgoingPlayer;
+    private static Tween? _outgoingFadeTween;
+    private static AudioStreamPlayer? _ambiencePlayer;
+    private static string? _currentAmbiencePath;
+    private static Tween? _ambienceFadeTween;
+
+    private const float MusicVolumeOffset = -6f;
+    private const float AmbienceVolumeOffset = -6f;
+    private const float SfxVolumeOffset = -3f;
+
+
+    public static void Register(string characterId, string modAudioResRoot)
+    {
+        if (string.IsNullOrWhiteSpace(characterId) || string.IsNullOrWhiteSpace(modAudioResRoot))
+            return;
+        CharacterIdToRoot[characterId] = modAudioResRoot.TrimEnd('/');
+    }
+
+    /// <summary>
+    /// Scans loaded assemblies for concrete <see cref="PlaceholderCharacterModel"/> types,
+    /// instantiates them, and registers non-empty <see cref="CustomCharacterModel.ModAudioPath"/>.
+    /// </summary>
+    public static void DiscoverPlaceholderCharacters()
+    {
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.IsDynamic)
+                continue;
+
+            IEnumerable<Type> types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                types = e.Types.Where(t => t != null)!;
+            }
+
+            foreach (var type in types)
+            {
+                if (type is null || type.IsAbstract || !typeof(PlaceholderCharacterModel).IsAssignableFrom(type))
+                    continue;
+                if (type.Assembly == typeof(PlaceholderCharacterModel).Assembly)
+                    continue;
+
+                CustomCharacterModel? instance;
+                try
+                {
+                    instance = Activator.CreateInstance(type) as CustomCharacterModel;
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (instance == null)
+                    continue;
+
+                var root = instance.ModAudioPath;
+                if (string.IsNullOrWhiteSpace(root))
+                    continue;
+
+                var id = instance is PlaceholderCharacterModel ph && !string.IsNullOrWhiteSpace(ph.PlaceholderID)
+                    ? ph.PlaceholderID
+                    : type.Name;
+
+                Register(id, root);
+            }
+        }
+    }
+
+    private static void EnsureDiscovered()
+    {
+        if (_discovered)
+            return;
+        _discovered = true;
+        DiscoverPlaceholderCharacters();
+    }
+
+    private static bool TryResolveRoot(string characterId, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
+    {
+        EnsureDiscovered();
+        return CharacterIdToRoot.TryGetValue(characterId, out root);
+    }
+
+    private static bool TryResolveRoot(CustomCharacterModel? model, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out string? root)
+    {
+        root = model?.ModAudioPath?.TrimEnd('/');
+        if (!string.IsNullOrEmpty(root))
+            return true;
+
+        EnsureDiscovered();
+        if (model is PlaceholderCharacterModel ph && !string.IsNullOrWhiteSpace(ph.PlaceholderID) &&
+            CharacterIdToRoot.TryGetValue(ph.PlaceholderID, out root))
+            return true;
+
+        return false;
+    }
+
+    public static void Play(string characterId, string folder, string soundName, float volume = 0f, float pitchVariation = 0f,
+        float basePitch = 1f)
+    {
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+        PlayFromRoot(modRoot, folder, soundName, volume, pitchVariation, basePitch);
+    }
+
+    public static void Play(CustomCharacterModel model, string folder, string soundName, float volume = 0f,
+        float pitchVariation = 0f, float basePitch = 1f)
+    {
+        if (!TryResolveRoot(model, out var modRoot))
+            return;
+        PlayFromRoot(modRoot, folder, soundName, volume, pitchVariation, basePitch);
+    }
+
+    private static void PlayFromRoot(string modRoot, string folder, string soundName, float volume, float pitchVariation,
+        float basePitch)
+    {
+        var stream = GetOrLoadStream(modRoot, folder, soundName);
+        if (stream == null)
+            return;
+
+        var player = new AudioStreamPlayer
+        {
+            Stream = stream,
+            VolumeDb = volume + SfxVolumeOffset,
+            Bus = "SFX",
+            PitchScale = pitchVariation > 0f
+                ? basePitch + (float)Rng.Chaotic.NextDouble() * 2f * pitchVariation - pitchVariation
+                : basePitch
+        };
+
+        var combatRoom = NCombatRoom.Instance;
+        if (combatRoom != null)
+        {
+            combatRoom.AddChild(player);
+            player.Play();
+            player.Finished += () => player.QueueFree();
+        }
+    }
+
+    /// <summary>Legacy-style call: creature parameter ignored (same as per-mod ModAudio).</summary>
+    public static void Play(Creature creature, string characterId, string folder, string soundName, float volume = 0f) =>
+        Play(characterId, folder, soundName, volume);
+
+    public static void PlaySfx(string characterId, string soundName, float volume = 0f, float pitchVariation = 0f) =>
+        Play(characterId, "", soundName, volume, pitchVariation);
+
+    public static void PlayGlobalSfx(string characterId, string soundName, float volume = 0f)
+    {
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+        PlayGlobalSfxFromRoot(modRoot, soundName, volume);
+    }
+
+    public static void PlayGlobalSfx(CustomCharacterModel model, string soundName, float volume = 0f)
+    {
+        if (!TryResolveRoot(model, out var modRoot))
+            return;
+        PlayGlobalSfxFromRoot(modRoot, soundName, volume);
+    }
+
+    private static void PlayGlobalSfxFromRoot(string modRoot, string soundName, float volume)
+    {
+        var stream = GetOrLoadStream(modRoot, "", soundName);
+        if (stream == null)
+            return;
+
+        var player = new AudioStreamPlayer
+        {
+            Stream = stream,
+            VolumeDb = volume + SfxVolumeOffset,
+            Bus = "SFX"
+        };
+
+        var tree = Engine.GetMainLoop() as SceneTree;
+        var root = tree?.Root;
+        if (root == null)
+            return;
+
+        root.AddChild(player);
+        player.Play();
+        player.Finished += () => player.QueueFree();
+    }
+
+    private static AudioStream? GetOrLoadStream(string modRoot, string folder, string soundName)
+    {
+        var key = $"{modRoot}|{(string.IsNullOrEmpty(folder) ? soundName : $"{folder}/{soundName}")}";
+        if (CachedStreams.TryGetValue(key, out var cached))
+            return cached;
+
+        var path = string.IsNullOrEmpty(folder)
+            ? $"{modRoot}/audio/sfx/{soundName}.ogg"
+            : $"{modRoot}/audio/sfx/{folder}/{soundName}.ogg";
+        var stream = GD.Load<AudioStream>(path);
+        if (stream != null)
+            CachedStreams[key] = stream;
+
+        return stream;
+    }
+
+    public static void PlayMusic(string characterId, string[] musicOptions, float volumeDbOffset = 0f)
+    {
+        if (musicOptions == null || musicOptions.Length == 0)
+            return;
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+
+        var musicName = musicOptions[GD.RandRange(0, musicOptions.Length - 1)];
+        var path = $"{modRoot}/audio/bgm/{musicName}.ogg";
+
+        if (_currentMusicPath == path && _musicPlayer?.Playing == true)
+            return;
+
+        StopMusic();
+
+        var stream = GD.Load<AudioStream>(path);
+        if (stream == null)
+            return;
+
+        if (stream is AudioStreamOggVorbis ogg)
+            ogg.Loop = true;
+
+        _musicPlayer = new AudioStreamPlayer
+        {
+            Stream = stream,
+            Bus = "Master"
+        };
+
+        _currentVolumeOffset = volumeDbOffset;
+        var bgmVolume = SaveManager.Instance.SettingsSave.VolumeBgm;
+        _musicPlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(bgmVolume, 2f)) + _currentVolumeOffset + MusicVolumeOffset;
+
+        var runNode = NRun.Instance;
+        if (runNode != null)
+        {
+            runNode.AddChild(_musicPlayer);
+            _musicPlayer.Play();
+            _currentMusicPath = path;
+        }
+    }
+
+    public static void SetMusicVolume(float volume)
+    {
+        if (_musicPlayer != null && GodotObject.IsInstanceValid(_musicPlayer))
+            _musicPlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(volume, 2f)) + _currentVolumeOffset + MusicVolumeOffset;
+    }
+
+    public static void FadeIn(string characterId, string[] musicOptions, float duration = 1.0f, float volumeDbOffset = 0f)
+    {
+        if (musicOptions == null || musicOptions.Length == 0)
+            return;
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+
+        var musicName = musicOptions[GD.RandRange(0, musicOptions.Length - 1)];
+        var path = $"{modRoot}/audio/bgm/{musicName}.ogg";
+
+        if (_currentMusicPath == path && _musicPlayer?.Playing == true)
+            return;
+
+        if (_musicPlayer != null && GodotObject.IsInstanceValid(_musicPlayer))
+        {
+            _outgoingFadeTween?.Kill();
+            _outgoingPlayer?.QueueFree();
+
+            _outgoingPlayer = _musicPlayer;
+            _outgoingFadeTween = _outgoingPlayer.CreateTween();
+            _outgoingFadeTween.TweenProperty(_outgoingPlayer, "volume_db", -80f, duration)
+                .SetTrans(Tween.TransitionType.Sine)
+                .SetEase(Tween.EaseType.In);
+            _outgoingFadeTween.TweenCallback(Callable.From(() =>
+            {
+                _outgoingPlayer?.QueueFree();
+                _outgoingPlayer = null;
+            }));
+        }
+
+        _fadeTween?.Kill();
+        _musicPlayer = null;
+        _currentMusicPath = null;
+
+        var stream = GD.Load<AudioStream>(path);
+        if (stream == null)
+            return;
+
+        if (stream is AudioStreamOggVorbis ogg)
+            ogg.Loop = true;
+
+        _musicPlayer = new AudioStreamPlayer
+        {
+            Stream = stream,
+            Bus = "Master",
+            VolumeDb = -80f
+        };
+
+        _currentVolumeOffset = volumeDbOffset;
+
+        var runNode = NRun.Instance;
+        if (runNode != null)
+        {
+            runNode.AddChild(_musicPlayer);
+            _musicPlayer.Play();
+            _currentMusicPath = path;
+
+            var targetDb = Mathf.LinearToDb(Mathf.Pow(SaveManager.Instance.SettingsSave.VolumeBgm, 2f))
+                + _currentVolumeOffset + MusicVolumeOffset;
+
+            _fadeTween = _musicPlayer.CreateTween();
+            _fadeTween.TweenProperty(_musicPlayer, "volume_db", targetDb, duration)
+                .SetTrans(Tween.TransitionType.Sine)
+                .SetEase(Tween.EaseType.Out);
+        }
+    }
+
+    public static void FadeOut(float duration = 1.0f)
+    {
+        if (_musicPlayer == null || !GodotObject.IsInstanceValid(_musicPlayer))
+            return;
+
+        _fadeTween?.Kill();
+        _fadeTween = _musicPlayer.CreateTween();
+        _fadeTween.TweenProperty(_musicPlayer, "volume_db", -80f, duration)
+            .SetTrans(Tween.TransitionType.Sine)
+            .SetEase(Tween.EaseType.In);
+        _fadeTween.TweenCallback(Callable.From(StopMusicImmediate));
+    }
+
+    private static void StopMusicImmediate()
+    {
+        _fadeTween?.Kill();
+        _fadeTween = null;
+        _outgoingFadeTween?.Kill();
+        _outgoingFadeTween = null;
+
+        if (_musicPlayer != null && GodotObject.IsInstanceValid(_musicPlayer))
+        {
+            _musicPlayer.Stop();
+            _musicPlayer.QueueFree();
+        }
+        _musicPlayer = null;
+        _currentMusicPath = null;
+
+        if (_outgoingPlayer != null && GodotObject.IsInstanceValid(_outgoingPlayer))
+        {
+            _outgoingPlayer.Stop();
+            _outgoingPlayer.QueueFree();
+        }
+        _outgoingPlayer = null;
+    }
+
+    public static void StopMusic() => StopMusicImmediate();
+
+    public static bool IsPlayingLegacyMusic() => _musicPlayer?.Playing == true;
+
+    public static void PlayAmbience(string characterId, string ambienceName, float volumeDbOffset = 0f)
+    {
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+
+        var path = $"{modRoot}/audio/bgm/{ambienceName}.ogg";
+
+        if (_currentAmbiencePath == path && _ambiencePlayer?.Playing == true)
+            return;
+
+        StopAmbience();
+
+        var stream = GD.Load<AudioStream>(path);
+        if (stream == null)
+            return;
+
+        if (stream is AudioStreamOggVorbis ogg)
+            ogg.Loop = true;
+
+        _ambiencePlayer = new AudioStreamPlayer
+        {
+            Stream = stream,
+            Bus = "Master"
+        };
+
+        var ambienceVolume = SaveManager.Instance.SettingsSave.VolumeAmbience;
+        _ambiencePlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(ambienceVolume, 2f)) + volumeDbOffset + AmbienceVolumeOffset;
+
+        var runNode = NRun.Instance;
+        if (runNode != null)
+        {
+            runNode.AddChild(_ambiencePlayer);
+            _ambiencePlayer.Play();
+            _currentAmbiencePath = path;
+        }
+    }
+
+    public static void FadeInAmbience(string characterId, string ambienceName, float duration = 1.0f,
+        float volumeDbOffset = 0f)
+    {
+        if (!TryResolveRoot(characterId, out var modRoot))
+            return;
+
+        var path = $"{modRoot}/audio/bgm/{ambienceName}.ogg";
+
+        if (_currentAmbiencePath == path && _ambiencePlayer?.Playing == true)
+            return;
+
+        StopAmbience();
+
+        var stream = GD.Load<AudioStream>(path);
+        if (stream == null)
+            return;
+
+        if (stream is AudioStreamOggVorbis ogg)
+            ogg.Loop = true;
+
+        _ambiencePlayer = new AudioStreamPlayer
+        {
+            Stream = stream,
+            Bus = "Master",
+            VolumeDb = -80f
+        };
+
+        var runNode = NRun.Instance;
+        if (runNode != null)
+        {
+            runNode.AddChild(_ambiencePlayer);
+            _ambiencePlayer.Play();
+            _currentAmbiencePath = path;
+
+            var targetDb = Mathf.LinearToDb(Mathf.Pow(SaveManager.Instance.SettingsSave.VolumeAmbience, 2f))
+                + volumeDbOffset + AmbienceVolumeOffset;
+
+            _ambienceFadeTween = _ambiencePlayer.CreateTween();
+            _ambienceFadeTween.TweenProperty(_ambiencePlayer, "volume_db", targetDb, duration)
+                .SetTrans(Tween.TransitionType.Sine)
+                .SetEase(Tween.EaseType.Out);
+        }
+    }
+
+    public static void FadeOutAmbience(float duration = 1.0f)
+    {
+        if (_ambiencePlayer == null || !GodotObject.IsInstanceValid(_ambiencePlayer))
+            return;
+
+        _ambienceFadeTween?.Kill();
+        _ambienceFadeTween = _ambiencePlayer.CreateTween();
+        _ambienceFadeTween.TweenProperty(_ambiencePlayer, "volume_db", -80f, duration)
+            .SetTrans(Tween.TransitionType.Sine)
+            .SetEase(Tween.EaseType.In);
+        _ambienceFadeTween.TweenCallback(Callable.From(StopAmbience));
+    }
+
+    public static void StopAmbience()
+    {
+        _ambienceFadeTween?.Kill();
+        _ambienceFadeTween = null;
+
+        if (_ambiencePlayer != null && GodotObject.IsInstanceValid(_ambiencePlayer))
+        {
+            _ambiencePlayer.Stop();
+            _ambiencePlayer.QueueFree();
+        }
+        _ambiencePlayer = null;
+        _currentAmbiencePath = null;
+    }
+
+    public static void SetAmbienceVolume(float volume)
+    {
+        if (_ambiencePlayer != null && GodotObject.IsInstanceValid(_ambiencePlayer))
+            _ambiencePlayer.VolumeDb = Mathf.LinearToDb(Mathf.Pow(volume, 2f)) + AmbienceVolumeOffset;
+    }
+}


### PR DESCRIPTION
**Credit**: Original approach by cany0udance, adapted for BaseLib as ModAudio.

What it does
Loads .ogg files from your mod’s Godot project using a resource path to the audio folder (the folder that contains sfx and bgm), so you don’t hard-code full paths everywhere.

Folder layout (your audio folder, e.g. res://ThePaladin/audio)

**Sound effects**: sfx/<name>.ogg
**Optional subfolder**: sfx/<folder>/<name>.ogg
**Music / ambience**: bgm/<name>.ogg
Hook it to your character

On your **CustomCharacterModel**, override **CustomAudioPath** and return that audio path (e.g. res://TheCharacter/audio).
Use **ModAudio.PlaySfx("Name", volumeDb)** etc. from your mod. If you only use one audio root, BaseLib infers it when your character is constructed; you can still call **ModAudio.SetRoot** to override or when you have multiple roots.
Optional: **ModAudio.Register("your_character_id", "res://YourMod/audio")** for id-based overloads, or **ModAudio.DiscoverPlaceholderCharacters()** for **PlaceholderCharacterModel** discovery.
Playing audio
Use **ModAudio** (PlaySfx, Play with optional folder, PlayGlobalSfx, PlayMusic, fades, ambience, …). Use **SetRoot**, a character id, or a CustomCharacterModel reference when you need to pick between multiple roots.

Note: Combat SFX attach to the combat room when it exists; global SFX use the scene tree as implemented in **ModAudio.

Example

If you have an audio file named SFX_Boom.ogg in your res://TheCharacter/audio/sfx folder:

using BaseLib.Utils;

in your customcharacter.cs:
public override string? CustomAudioPath => "res://TheCharacter/audio";

then somewhere in your class e.g. (example from rhythm girl card)
ModAudio.PlaySfx("SFX_JabExhaust", 5f);