### PR TITLE
fix(ui): Solve the floating-point precision issue of the slider component

### DIFF
--- a/Config/UI/NConfigSlider.cs
+++ b/Config/UI/NConfigSlider.cs
@@ -110,6 +110,14 @@ public partial class NConfigSlider : Control
     {
         var realValue = proxyValue + _realMin;
 
+        // Round to avoid floating point precision issues
+        var step = _slider.Step;
+        if (step > 0)
+        {
+            var decimalPlaces = BitConverter.GetBytes(decimal.GetBits((decimal)step)[3])[2];
+            realValue = Math.Round(realValue, decimalPlaces);
+        }
+
         _property?.SetValue(null, realValue);
         _config?.Changed();
         UpdateLabel(realValue);


### PR DESCRIPTION
fix bug like this.. (min, max, step) = (0.1, 10, 0.1)
<img width="873" height="360" alt="bug" src="https://github.com/user-attachments/assets/c1c81cb1-41e2-4d81-807f-7d937324f4ab" />
