### PR TITLE
Create Custom Orb Model

### DIFF
--- a/Abstracts/CustomOrbModel.cs
+++ b/Abstracts/CustomOrbModel.cs
@@ -21,6 +21,10 @@ public abstract class CustomOrbModel : OrbModel, ICustomModel
     public virtual string? CustomEvokeSfx => null;
     public virtual string? CustomChannelSfx => null;
 
+    protected override string PassiveSfx => CustomPassiveSfx ?? base.PassiveSfx;
+    protected override string EvokeSfx => CustomEvokeSfx ?? base.EvokeSfx;
+    protected override string ChannelSfx => CustomChannelSfx ?? base.ChannelSfx;
+
     /// <summary>
     /// Override to create a custom sprite for this orb.
     /// If null is returned, falls back to CustomSpritePath or the default sprite.
@@ -73,45 +77,6 @@ class CustomOrbCreateSprite
             return true;
 
         __result = sprite;
-        return false;
-    }
-}
-
-[HarmonyPatch(typeof(OrbModel), "PassiveSfx", MethodType.Getter)]
-class CustomOrbPassiveSfx
-{
-    [HarmonyPrefix]
-    static bool Custom(OrbModel __instance, ref string __result)
-    {
-        if (__instance is not CustomOrbModel custom || custom.CustomPassiveSfx is not string sfx)
-            return true;
-        __result = sfx;
-        return false;
-    }
-}
-
-[HarmonyPatch(typeof(OrbModel), "EvokeSfx", MethodType.Getter)]
-class CustomOrbEvokeSfx
-{
-    [HarmonyPrefix]
-    static bool Custom(OrbModel __instance, ref string __result)
-    {
-        if (__instance is not CustomOrbModel custom || custom.CustomEvokeSfx is not string sfx)
-            return true;
-        __result = sfx;
-        return false;
-    }
-}
-
-[HarmonyPatch(typeof(OrbModel), "ChannelSfx", MethodType.Getter)]
-class CustomOrbChannelSfx
-{
-    [HarmonyPrefix]
-    static bool Custom(OrbModel __instance, ref string __result)
-    {
-        if (__instance is not CustomOrbModel custom || custom.CustomChannelSfx is not string sfx)
-            return true;
-        __result = sfx;
         return false;
     }
 }


### PR DESCRIPTION
I was creating a new orb for my mod, and wanted to remain consistent with BaseLibs patterns, so I forked and made the CustomOrbModel class --

Has the CustomIconPath (for tooltips) and CustomSpritePath (to show in game), as you would expect. Also includes CustomPassivsSfx, CustomEvokeSfx, and CustomChannelSfx.

`CreateCustomSprite` is a function, empty by default, but allows you to programatically use (mix n match) existing game assets to create new orbs! Examples below! 

`public virtual bool IncludeInRandomPool => false;` by default, new orbs will NOT show up in cards like [chaos](https://sts2.untapped.gg/en/cards/chaos) - but if you set this to `true`, it will patch `OrbModel.GetRandomOrb` to add your orb to the random pool.

---

Using the new CustomOrbModel, my actual mod code for new `FireOrb`:

```cs
public class FireOrb : CustomOrbModel
{
    private static readonly Color LightningLayerColor = new(0.8f, 0.1f, 0.0f, 1.0f);
    private static readonly Color GlassLayerColor = new(0.95f, 0.75f, 0.2f, 1.0f);

    public override Color DarkenedColor => new Color("996510");
    public override string? CustomIconPath => "res://BurningMod/images/powers/beta/burningmod-burn_power.png";
    public override bool IncludeInRandomPool => true;

    public override decimal PassiveVal => ModifyOrbValue(2m);
    public override decimal EvokeVal => ModifyOrbValue(4m);

    public override Node2D? CreateCustomSprite()
    {
        var container = new Node2D();

        // Back layer: lightning orb (red crackling aura), 10% bigger
        string lightningPath = SceneHelper.GetScenePath("orbs/orb_visuals/lightning_orb");
        Node2D lightning = PreloadManager.Cache.GetScene(lightningPath)
            .Instantiate<Node2D>(PackedScene.GenEditState.Disabled);
        new MegaSprite(lightning.GetNode("SpineSkeleton"))
            .GetAnimationState().SetAnimation("idle_loop");
        lightning.Modulate = LightningLayerColor;
        lightning.Scale = new Vector2(1.1f, 1.1f);
        container.AddChild(lightning);

        // Front layer: glass orb (orange)
        string glassPath = SceneHelper.GetScenePath("orbs/orb_visuals/glass_orb");
        Node2D glass = PreloadManager.Cache.GetScene(glassPath)
            .Instantiate<Node2D>(PackedScene.GenEditState.Disabled);
        new MegaSprite(glass.GetNode("SpineSkeleton"))
            .GetAnimationState().SetAnimation("idle_loop");
        glass.Modulate = GlassLayerColor;
        container.AddChild(glass);

        return container;
    }

    public override async Task BeforeTurnEndOrbTrigger(PlayerChoiceContext choiceContext)
    {
        await Passive(choiceContext, null);
    }

    public override async Task Passive(PlayerChoiceContext choiceContext, Creature? target)
    {
        Trigger();
                ... logic cut out for brevity ...
    }

    public override async Task<IEnumerable<Creature>> Evoke(PlayerChoiceContext choiceContext)
    {
                ... logic cut out for brevity ...
    }
}
```

The most exciting part for me is `CreateCustomSprite` - notice how I override the function to pull in two existing orbs to change their colors, size, and positioning, to  layer them together and create a new visual! It's super fun to play around with, and it should open up creative opportunities for mod makers who don't have the time or skills to animate new sprites from scratch!


<img width="619" height="532" alt="image" src="https://github.com/user-attachments/assets/743569ed-e3f7-4ed6-a155-988198a1d2b8" />

Confirmed working in game, no errors, no warnings.

Also here is a video confirming the optional random pool patch works:

https://github.com/user-attachments/assets/630262aa-f2c1-429d-851e-91b39a933ebc


