### PR TITLE
fix: log window sizing for ultrawide/HiDPI and unified font zoom

### DIFF
--- a/BaseLib/scenes/LogWindow.tscn
+++ b/BaseLib/scenes/LogWindow.tscn
@@ -33,7 +33,6 @@ corner_radius_bottom_left = 3
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_log"]
 
 [node name="LogWindow" type="Window"]
-oversampling_override = 1.0
 title = "Log"
 initial_position = 3
 size = Vector2i(600, 400)

--- a/BaseLibScenes/NLogWindow.cs
+++ b/BaseLibScenes/NLogWindow.cs
@@ -24,6 +24,7 @@ public partial class NLogWindow : Window
 
     private ScrollContainer? _scrollContainer;
     private RichTextLabel? _logLabel;
+    private Label? _logLevelLabel;
     private OptionButton? _logLevelDropdown;
     private LineEdit? _filterInput;
     private Button? _regexButton;
@@ -58,6 +59,7 @@ public partial class NLogWindow : Window
 
         _scrollContainer = GetNode<ScrollContainer>("MainVBox/Scroll");
         _logLabel = GetNode<RichTextLabel>("MainVBox/Scroll/Log");
+        _logLevelLabel = GetNode<Label>("MainVBox/TopBarContainer/TopBarHBox/LogLevelLabel");
         _logLevelDropdown = GetNode<OptionButton>("MainVBox/TopBarContainer/TopBarHBox/LogLevelOption");
         _filterInput = GetNode<LineEdit>("MainVBox/TopBarContainer/TopBarHBox/FilterText");
         _regexButton = GetNode<Button>("MainVBox/TopBarContainer/TopBarHBox/RegexButton");
@@ -91,7 +93,29 @@ public partial class NLogWindow : Window
         _isFollowingLog = true;
 
         SetFontSize(_currentFontSize, false);
+        ApplyMinSizeForScale();
         UpdateFilter(); // Also calls Refresh()
+    }
+
+    private void ApplyMinSizeForScale()
+    {
+        float s = ContentScaleFactor > 0f ? ContentScaleFactor : 1f;
+        MinSize = new Vector2I((int)(360 * s), (int)(66 * s));
+    }
+
+    private void ApplyChromeFontSize(int size)
+    {
+        _logLevelLabel?.AddThemeFontSizeOverrideAll(size);
+        _logLevelDropdown?.AddThemeFontSizeOverrideAll(size);
+        _filterInput?.AddThemeFontSizeOverrideAll(size);
+        _regexButton?.AddThemeFontSizeOverrideAll(size);
+        _inverseButton?.AddThemeFontSizeOverrideAll(size);
+
+        int dim = Mathf.Max(28, (int)(size * 1.25f));
+        if (_regexButton is not null)
+            _regexButton.CustomMinimumSize = new Vector2(dim, dim);
+        if (_inverseButton is not null)
+            _inverseButton.CustomMinimumSize = new Vector2(dim, dim);
     }
 
     private void UpdateFilter()
@@ -223,6 +247,7 @@ public partial class NLogWindow : Window
     private void SetFontSize(int newSize, bool save = true)
     {
         _logLabel?.AddThemeFontSizeOverrideAll(newSize);
+        ApplyChromeFontSize(newSize);
         _currentFontSize = newSize;
         ScrollToBottomAsync();
 

--- a/Commands/LogWindowPlacement.cs
+++ b/Commands/LogWindowPlacement.cs
@@ -1,0 +1,38 @@
+using BaseLib.BaseLibScenes;
+using Godot;
+
+namespace BaseLib.Commands;
+
+/// <summary>
+/// Sizes and positions the log window relative to the game window so ultrawide / multi-monitor
+/// setups do not inherit a full-screen-width two-thirds rectangle.
+/// </summary>
+internal static class LogWindowPlacement
+{
+    internal static Vector2I ComputeDefaultSize(Vector2I hostSize)
+    {
+        if (hostSize.X <= 0 || hostSize.Y <= 0)
+            return new Vector2I(800, 600);
+
+        int tw = hostSize.X * 2 / 3;
+        int th = hostSize.Y * 2 / 3;
+
+        // Avoid an extremely wide panel on ultrawide / super-ultrawide fullscreen.
+        int maxReadableW = Mathf.Clamp((int)(th * 2.35f), 960, 2048);
+        tw = Mathf.Min(tw, maxReadableW);
+
+        tw = Mathf.Min(tw, Mathf.Max(320, hostSize.X - 32));
+        th = Mathf.Min(th, Mathf.Max(200, hostSize.Y - 32));
+
+        return new Vector2I(tw, th);
+    }
+
+    internal static void ApplyHostWindowDefaults(NLogWindow logWindow, Window host)
+    {
+        logWindow.CurrentScreen = host.CurrentScreen;
+        if (host.ContentScaleFactor > 0f)
+            logWindow.ContentScaleFactor = host.ContentScaleFactor;
+
+        logWindow.Size = ComputeDefaultSize(host.Size);
+    }
+}

--- a/Commands/OpenLogWindow.cs
+++ b/Commands/OpenLogWindow.cs
@@ -1,4 +1,4 @@
-﻿using BaseLib.BaseLibScenes;
+using BaseLib.BaseLibScenes;
 using Godot;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.DevConsole;
@@ -31,7 +31,7 @@ public class OpenLogWindow : AbstractConsoleCmd
         window.GuiEmbedSubwindows = false;
         
         var scene = PreloadManager.Cache.GetScene("res://BaseLib/scenes/LogWindow.tscn").Instantiate<NLogWindow>();
-        scene.Size = DisplayServer.ScreenGetSize() * 2 / 3;
+        LogWindowPlacement.ApplyHostWindowDefaults(scene, window);
         window.AddChildSafely(scene);
     }
 }


### PR DESCRIPTION
- Size from game window with capped width; sync CurrentScreen and ContentScaleFactor
- Remove Window oversampling override (inherit engine default)
- Scale min size with content scale; Ctrl+wheel applies to log chrome as well

Issue: #77 