### PR TITLE
Add implicit operator for StaticHoverTip to TooltipSource

### DIFF
--- a/Utils/TooltipSource.cs
+++ b/Utils/TooltipSource.cs
@@ -32,4 +32,5 @@ public class TooltipSource
         throw new Exception($"Unable to generate hovertip from type {t}");
     }
     public static implicit operator TooltipSource(CardKeyword keyword) => new((card)=>HoverTipFactory.FromKeyword(keyword));
+    public static implicit operator TooltipSource(StaticHoverTip staticTip) => new(card => HoverTipFactory.Static(staticTip));
 }


### PR DESCRIPTION
Adding standard tooltips like Stun, Forge, or Block currently requires a verbose lambda for ConstructedCardModel:
`WithTip(new TooltipSource(_ => HoverTipFactory.Static(StaticHoverTip.Stun)));`

I just added the pretty version as I needed it a lot.
`WithTip(StaticHoverTip.Stun)`
consistent with CardKeywords.