### PR TITLE
CustomCardModel's CustomPortraitPath isnt applied to Portait

### DIFF
--- a/Abstracts/CustomCardModel.cs
+++ b/Abstracts/CustomCardModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Cards;
@@ -23,6 +24,7 @@ public abstract class CustomCardModel : CardModel, ICustomModel, ILocalizationPr
 
     public virtual Texture2D? CustomFrame => null;
     public virtual string? CustomPortraitPath => null;
+    public virtual Texture2D? CustomPortrait => null;
     public virtual List<(string, string)>? Localization => null;
 }
 
@@ -48,7 +50,7 @@ class CustomCardFrame
 }
 
 [HarmonyPatch(typeof(CardModel), "PortraitPngPath", MethodType.Getter)]
-class CustomCardPortraitPath
+class CustomCardPortraitPngPath
 {
     [HarmonyPrefix]
     static bool UseAltTexture(CardModel __instance, ref string? __result)
@@ -56,6 +58,36 @@ class CustomCardPortraitPath
         if (__instance is not CustomCardModel customCard) return true;
         
         __result = customCard.CustomPortraitPath;
+        return __result == null;
+    }
+}
+
+[HarmonyPatch(typeof(CardModel), "Portrait", MethodType.Getter)]
+class CustomCardPortrait
+{
+    [HarmonyPrefix]
+    static bool UseAltTexture(CardModel __instance, ref Texture2D? __result)
+    {
+        if (__instance is not CustomCardModel customCard) return true;
+        
+        __result = customCard.CustomPortrait ?? ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath);
+        return __result == null;
+    }
+}
+
+[HarmonyPatch(typeof(CardModel), "PortraitPath", MethodType.Getter)]
+class CustomCardPortraitPath
+{
+    [HarmonyPrefix]
+    static bool UseAltTexture(CardModel __instance, ref string? __result)
+    {
+        if (__instance is not CustomCardModel customCard) return true;
+
+        if (customCard.CustomPortrait == null) {
+            __result = ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath).ResourcePath;
+        } else {
+            __result = customCard.CustomPortrait.ResourcePath;
+        }
         return __result == null;
     }
 }


### PR DESCRIPTION
`@johnnybazooka89` On the Sts2 Modding Discord Channel has discovered that the `PortraitPngPath` isnt used for much so i made some changes that fixes that.
I also added some `CustomPortrait` of type `Texture2D` incase in the future someone wanted to programmatically create a Portrait which i find very likely.