### PR TITLE
Add automatic scene type conversion via Instantiate postfix

### DIFF
--- a/Abstracts/CustomCharacterModel.cs
+++ b/Abstracts/CustomCharacterModel.cs
@@ -267,12 +267,71 @@ public class ModelDbCustomCharacters
     [HarmonyPostfix]
     public static IEnumerable<CharacterModel> AddCustomPools(IEnumerable<CharacterModel> __result)
     {
+        EnsureScenePathsRegistered();
         return [.. __result, .. CustomCharacters];
     }
 
     public static void Register(CustomCharacterModel character)
     {
         CustomCharacters.Add(character);
+    }
+
+    /// <summary>
+    /// Registers scene paths for all custom characters that haven't been registered yet.
+    /// Called lazily (from AddCustomPools) rather than from the constructor, because
+    /// virtual properties like CustomVisualPath may depend on fields set in derived
+    /// constructors that haven't run yet when Register() is called from the base ctor.
+    /// </summary>
+    /// <remarks>
+    /// Tracks the last-registered paths per character so that re-registration after a
+    /// path change correctly unregisters the stale mapping first.
+    /// </remarks>
+    private static readonly Dictionary<CustomCharacterModel, (string? visualPath, string? energyPath)> _registeredPaths = [];
+
+    internal static void EnsureScenePathsRegistered()
+    {
+        foreach (var character in CustomCharacters)
+        {
+            var visualPath = character.CustomVisualPath;
+            var energyPath = character.GetCustomEnergyCounterAssetPath();
+
+            if (_registeredPaths.TryGetValue(character, out var prev))
+            {
+                // Already registered — check if paths changed (e.g. mod update / hot reload)
+                if (prev.visualPath == visualPath && prev.energyPath == energyPath)
+                    continue;
+
+                // Unregister stale paths before re-registering
+                UnregisterCharacterPaths(prev.visualPath, prev.energyPath);
+            }
+
+            if (visualPath != null)
+                NodeFactory.RegisterSceneType<NCreatureVisuals>(visualPath);
+            if (energyPath != null)
+                NodeFactory.RegisterSceneType<NEnergyCounter>(energyPath);
+
+            _registeredPaths[character] = (visualPath, energyPath);
+        }
+    }
+
+    /// <summary>
+    /// Unregisters all scene paths registered by custom characters.
+    /// Call this during cleanup or before re-initialization.
+    /// </summary>
+    public static void UnregisterAllCharacterScenePaths()
+    {
+        foreach (var (visualPath, energyPath) in _registeredPaths.Values)
+            UnregisterCharacterPaths(visualPath, energyPath);
+
+        _registeredPaths.Clear();
+    }
+
+    private static void UnregisterCharacterPaths(string? visualPath, string? energyPath)
+    {
+        if (visualPath != null)
+            NodeFactory.UnregisterSceneType(visualPath);
+        if (energyPath != null)
+            NodeFactory.UnregisterSceneType(energyPath);
     }
 }
 

--- a/Patches/Content/InstantiatePatch.cs
+++ b/Patches/Content/InstantiatePatch.cs
@@ -1,0 +1,43 @@
+using System.Reflection;
+using BaseLib.Utils.NodeFactories;
+using Godot;
+using HarmonyLib;
+
+namespace BaseLib.Patches.Content;
+
+/// <summary>
+/// Patches the non-generic PackedScene.Instantiate so that registered scenes
+/// are auto-converted to the correct node type before Instantiate&lt;T&gt;'s castclass runs.
+///
+/// This makes it so modders can use standard Godot scenes (Node2D root, etc)
+/// and have them transparently converted to game types like NCreatureVisuals
+/// without needing per-callsite Harmony patches.
+///
+/// Uses TargetMethod to avoid ambiguity between the generic and non-generic overloads.
+/// </summary>
+[HarmonyPatch]
+static class InstantiatePatch
+{
+    static MethodBase TargetMethod()
+    {
+        // Explicitly pick the non-generic Instantiate(GenEditState), not Instantiate<T>(GenEditState)
+        var method = typeof(PackedScene).GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .FirstOrDefault(m => m.Name == "Instantiate"
+                        && !m.IsGenericMethodDefinition
+                        && m.GetParameters().Length == 1
+                        && m.GetParameters()[0].ParameterType == typeof(PackedScene.GenEditState));
+
+        if (method == null)
+            throw new InvalidOperationException(
+                "Could not find PackedScene.Instantiate(GenEditState). " +
+                "The Godot API may have changed — auto-conversion will not work.");
+
+        return method;
+    }
+
+    [HarmonyPostfix]
+    static void Postfix(PackedScene __instance, ref Node __result)
+    {
+        NodeFactory.TryAutoConvert(__instance, ref __result);
+    }
+}

--- a/Utils/NodeFactories/NodeFactory.cs
+++ b/Utils/NodeFactories/NodeFactory.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿using System.Collections.Concurrent;
+using Godot;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 
@@ -16,6 +17,7 @@ public abstract class NodeFactory<T> : NodeFactory where T : Node, new()
     protected NodeFactory(IEnumerable<INodeInfo> namedNodes) : base(namedNodes)
     {
         _instance = this;
+        RegisterFactory(typeof(T), this);
         BaseLibMain.Logger.Info($"Created node factory for {typeof(T).Name}.");
     }
 
@@ -166,6 +168,13 @@ public abstract class NodeFactory<T> : NodeFactory where T : Node, new()
         }
     }
 
+    internal override Node CreateAndConvert(Node source)
+    {
+        var target = new T();
+        ConvertScene(target, source);
+        return target;
+    }
+
     /// <summary>
     /// This method should convert the given node into the target type, or call the base method if unsupported.
     /// The given node should either be freed or incorporated as a child of the generated node.
@@ -194,13 +203,386 @@ public abstract class NodeFactory<T> : NodeFactory where T : Node, new()
 
 public abstract class NodeFactory
 {
+    // Both dictionaries are concurrent — _factories is written during Init on the main thread
+    // and read from the Instantiate postfix which can fire from any thread during asset loading.
+    private static readonly ConcurrentDictionary<Type, NodeFactory> _factories = new();
+    private static readonly ConcurrentDictionary<string, Type> _sceneTypes = new();
+
+    // Prevents recursion when the postfix triggers during a factory conversion.
+    // ThreadStatic is correct here: Godot node creation is main-thread, but this also
+    // makes us safe if background asset loading ever calls Instantiate.
+    [ThreadStatic]
+    private static bool _isConverting;
+
     public static void Init()
     {
         new ControlFactory();
         new NCreatureVisualsFactory();
         new NEnergyCounterFactory();
+
+        RunSelfTests();
     }
-    
+
+    /// <summary>
+    /// Register a scene path to be auto-converted to the specified node type on Instantiate.
+    /// The node type must have a NodeFactory registered for it.
+    /// </summary>
+    public static void RegisterSceneType<TNode>(string scenePath) where TNode : Node
+    {
+        RegisterSceneType(scenePath, typeof(TNode));
+    }
+
+    /// <summary>
+    /// Register a scene path to be auto-converted to the specified node type on Instantiate.
+    /// Logs a warning if the path was already registered for a different type (silent overwrite).
+    /// </summary>
+    public static void RegisterSceneType(string scenePath, Type nodeType)
+    {
+        if (string.IsNullOrWhiteSpace(scenePath))
+        {
+            BaseLibMain.Logger.Warn($"Ignoring RegisterSceneType({nodeType.Name}) with null/empty path");
+            return;
+        }
+
+        if (_sceneTypes.TryGetValue(scenePath, out var existing) && existing != nodeType)
+            BaseLibMain.Logger.Warn($"Overwriting scene registration for '{scenePath}': {existing.Name} → {nodeType.Name}");
+
+        _sceneTypes[scenePath] = nodeType;
+        BaseLibMain.Logger.Info($"Registered scene '{scenePath}' for auto-conversion to {nodeType.Name}");
+    }
+
+    /// <summary>
+    /// Remove a previously registered scene path. Safe to call even if the path was never registered.
+    /// </summary>
+    public static void UnregisterSceneType(string scenePath)
+    {
+        _sceneTypes.TryRemove(scenePath, out _);
+    }
+
+    /// <summary>
+    /// Check whether a factory is registered for the given node type.
+    /// </summary>
+    public static bool HasFactory<TNode>() where TNode : Node => _factories.ContainsKey(typeof(TNode));
+
+    /// <summary>
+    /// Check whether a scene path is registered for auto-conversion.
+    /// </summary>
+    public static bool IsRegistered(string scenePath) => !string.IsNullOrEmpty(scenePath) && _sceneTypes.ContainsKey(scenePath);
+
+    internal static void RegisterFactory(Type nodeType, NodeFactory factory)
+    {
+        _factories[nodeType] = factory;
+    }
+
+    // Tracks which paths have already logged a conversion, to avoid log spam.
+    // ConcurrentDictionary for thread safety — same contract as _factories/_sceneTypes.
+    private static readonly ConcurrentDictionary<string, byte> _loggedConversions = new();
+
+    /// <summary>
+    /// Checks if the instantiated node needs auto-conversion based on registered scene types,
+    /// and performs the conversion if a matching factory exists.
+    /// Called from the PackedScene.Instantiate postfix.
+    ///
+    /// When CreateFromScene also calls Instantiate internally, the postfix handles the conversion
+    /// and CreateFromScene's "if (n is T t) return t" short-circuits — both paths produce the same result.
+    /// </summary>
+    internal static bool TryAutoConvert(PackedScene scene, ref Node result)
+    {
+        if (_isConverting || result == null) return false;
+
+        var path = scene.ResourcePath;
+        if (string.IsNullOrEmpty(path)) return false;
+        if (!_sceneTypes.TryGetValue(path, out var expectedType)) return false;
+        if (expectedType.IsAssignableFrom(result.GetType())) return false; // already the right type
+
+        if (!_factories.TryGetValue(expectedType, out var factory))
+        {
+            BaseLibMain.Logger.Warn($"Scene '{path}' registered for {expectedType.Name} but no factory exists for that type");
+            return false;
+        }
+
+        _isConverting = true;
+        try
+        {
+            var sourceTypeName = result.GetType().Name;
+            var converted = factory.CreateAndConvert(result);
+
+            // Only log the first conversion per path to avoid spam (monsters get instantiated a lot)
+            if (_loggedConversions.TryAdd(path, 0))
+                BaseLibMain.Logger.Info($"Auto-converted '{path}' from {sourceTypeName} to {converted.GetType().Name}");
+
+            result = converted;
+            return true;
+        }
+        catch (Exception e)
+        {
+            // CreateAndConvert is destructive — it reparents children from the source node
+            // and may QueueFree it. If conversion fails midway, the original __result is
+            // corrupted (children stripped, possibly queued for deletion). We MUST NOT return
+            // false and let the caller use the mangled node. Re-throw so the failure is visible.
+            BaseLibMain.Logger.Error($"Auto-conversion failed for '{path}' — the instantiated node is likely corrupt: {e}");
+            throw;
+        }
+        finally
+        {
+            _isConverting = false;
+        }
+    }
+
+    /// <summary>
+    /// Create a new instance of the factory's target type and convert the source node into it.
+    /// Used by auto-conversion to avoid calling Instantiate again.
+    /// </summary>
+    internal abstract Node CreateAndConvert(Node source);
+
+    //-- Self-tests: run once at init to verify the whole postfix → factory pipeline works --
+
+    private static int _testsPassed;
+    private static int _testsFailed;
+
+    private static void RunSelfTests()
+    {
+        _testsPassed = 0;
+        _testsFailed = 0;
+
+        TestCreatureVisualsConversion();
+        TestGenericInstantiateChain();
+        TestControlConversion();
+        TestAlreadyCorrectTypePassthrough();
+        TestUnregisteredScenePassthrough();
+        TestNullAndEmptyPathValidation();
+        TestOverwriteAndUnregister();
+        TestQueryApis();
+
+        if (_testsFailed == 0)
+            BaseLibMain.Logger.Info($"All {_testsPassed} auto-conversion self-tests passed");
+        else
+            BaseLibMain.Logger.Error($"Auto-conversion self-tests: {_testsPassed} passed, {_testsFailed} FAILED");
+
+        _testsPassed = 0;
+        _testsFailed = 0;
+    }
+
+    private static void Assert(bool condition, string testName)
+    {
+        if (condition)
+            _testsPassed++;
+        else
+        {
+            _testsFailed++;
+            BaseLibMain.Logger.Error($"FAIL: {testName}");
+        }
+    }
+
+    /// <summary>
+    /// Pack a Node2D scene with creature-like children, register it, Instantiate, expect NCreatureVisuals.
+    /// </summary>
+    private static void TestCreatureVisualsConversion()
+    {
+        const string path = "res://baselib_test/creature.tscn";
+        try
+        {
+            var root = new Node2D { Name = "TestCreature" };
+            AddOwnedChild(root, new Sprite2D { Name = "Visuals", UniqueNameInOwner = true });
+            AddOwnedChild(root, new Control { Name = "Bounds", Size = new Vector2(200, 240), Position = new Vector2(-100, -240) });
+            AddOwnedChild(root, new Marker2D { Name = "IntentPos" });
+            AddOwnedChild(root, new Marker2D { Name = "CenterPos", UniqueNameInOwner = true });
+
+            var scene = new PackedScene();
+            scene.Pack(root);
+            root.QueueFree();
+            scene.ResourcePath = path;
+
+            _sceneTypes[path] = typeof(MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals);
+
+            var result = scene.Instantiate(PackedScene.GenEditState.Disabled);
+            Assert(result is MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals, "NCreatureVisuals conversion");
+            result.QueueFree();
+        }
+        catch (Exception e) { Assert(false, $"NCreatureVisuals conversion (threw: {e.Message})"); }
+        finally { _sceneTypes.TryRemove(path, out _); _loggedConversions.TryRemove(path, out _); }
+    }
+
+    /// <summary>
+    /// Pack a Node2D, register for Control, Instantiate, expect Control.
+    /// </summary>
+    private static void TestControlConversion()
+    {
+        const string path = "res://baselib_test/control.tscn";
+        try
+        {
+            var root = new Node2D { Name = "TestControl" };
+
+            var scene = new PackedScene();
+            scene.Pack(root);
+            root.QueueFree();
+            scene.ResourcePath = path;
+
+            _sceneTypes[path] = typeof(Control);
+
+            var result = scene.Instantiate(PackedScene.GenEditState.Disabled);
+            Assert(result is Control, "Control conversion");
+            result.QueueFree();
+        }
+        catch (Exception e) { Assert(false, $"Control conversion (threw: {e.Message})"); }
+        finally { _sceneTypes.TryRemove(path, out _); _loggedConversions.TryRemove(path, out _); }
+    }
+
+    /// <summary>
+    /// Register a scene whose root is already the expected type — should pass through with no conversion.
+    /// </summary>
+    private static void TestAlreadyCorrectTypePassthrough()
+    {
+        const string path = "res://baselib_test/passthrough.tscn";
+        try
+        {
+            var root = new Control { Name = "AlreadyControl" };
+
+            var scene = new PackedScene();
+            scene.Pack(root);
+            root.QueueFree();
+            scene.ResourcePath = path;
+
+            _sceneTypes[path] = typeof(Control);
+
+            var result = scene.Instantiate(PackedScene.GenEditState.Disabled);
+            // Should still be Control (no conversion needed), and specifically should NOT
+            // have gone through CreateAndConvert (it would still be Control either way,
+            // but IsAssignableFrom should short-circuit).
+            Assert(result is Control, "Already-correct-type passthrough");
+            result.QueueFree();
+        }
+        catch (Exception e) { Assert(false, $"Already-correct-type passthrough (threw: {e.Message})"); }
+        finally { _sceneTypes.TryRemove(path, out _); }
+    }
+
+    /// <summary>
+    /// Instantiate a scene that is NOT registered — should return the raw node unchanged.
+    /// </summary>
+    private static void TestUnregisteredScenePassthrough()
+    {
+        const string path = "res://baselib_test/unregistered.tscn";
+        try
+        {
+            var root = new Node2D { Name = "Unregistered" };
+
+            var scene = new PackedScene();
+            scene.Pack(root);
+            root.QueueFree();
+            scene.ResourcePath = path;
+            // Deliberately NOT registering this path
+
+            var result = scene.Instantiate(PackedScene.GenEditState.Disabled);
+            Assert(result is Node2D, "Unregistered scene passthrough");
+            Assert(result.GetType() == typeof(Node2D), "Unregistered scene is exactly Node2D");
+            result.QueueFree();
+        }
+        catch (Exception e) { Assert(false, $"Unregistered scene passthrough (threw: {e.Message})"); }
+    }
+
+    /// <summary>
+    /// THE critical test: call the generic Instantiate&lt;NCreatureVisuals&gt;() which is what game
+    /// code actually uses. Verifies the postfix on the non-generic Instantiate fires and converts
+    /// the node BEFORE the (T)(object) cast in the generic method.
+    /// If this test passes, the entire approach works end-to-end.
+    /// </summary>
+    private static void TestGenericInstantiateChain()
+    {
+        const string path = "res://baselib_test/generic_chain.tscn";
+        try
+        {
+            var root = new Node2D { Name = "GenericChainTest" };
+            AddOwnedChild(root, new Sprite2D { Name = "Visuals", UniqueNameInOwner = true });
+            AddOwnedChild(root, new Control { Name = "Bounds", Size = new Vector2(200, 240), Position = new Vector2(-100, -240) });
+            AddOwnedChild(root, new Marker2D { Name = "IntentPos" });
+            AddOwnedChild(root, new Marker2D { Name = "CenterPos", UniqueNameInOwner = true });
+
+            var scene = new PackedScene();
+            scene.Pack(root);
+            root.QueueFree();
+            scene.ResourcePath = path;
+
+            _sceneTypes[path] = typeof(MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals);
+
+            // This is the real deal — Instantiate<T> calls Instantiate() then casts to T.
+            // Our postfix on Instantiate() must convert BEFORE the cast, or this throws InvalidCastException.
+            var result = scene.Instantiate<MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals>(PackedScene.GenEditState.Disabled);
+            Assert(result is MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals, "Generic Instantiate<NCreatureVisuals> chain");
+            result.QueueFree();
+        }
+        catch (InvalidCastException)
+        {
+            Assert(false, "Generic Instantiate<NCreatureVisuals> chain (InvalidCastException — postfix didn't fire before cast!)");
+        }
+        catch (Exception e)
+        {
+            Assert(false, $"Generic Instantiate<NCreatureVisuals> chain (threw: {e.Message})");
+        }
+        finally { _sceneTypes.TryRemove(path, out _); _loggedConversions.TryRemove(path, out _); }
+    }
+
+    /// <summary>
+    /// Verify that null/empty paths are rejected by RegisterSceneType.
+    /// </summary>
+    private static void TestNullAndEmptyPathValidation()
+    {
+        var countBefore = _sceneTypes.Count;
+        RegisterSceneType<Control>(null!);
+        RegisterSceneType<Control>("");
+        RegisterSceneType<Control>("   ");
+        Assert(_sceneTypes.Count == countBefore, "Null/empty/whitespace paths rejected");
+    }
+
+    /// <summary>
+    /// Verify overwrite and unregister work correctly.
+    /// </summary>
+    private static void TestOverwriteAndUnregister()
+    {
+        const string path = "res://baselib_test/overwrite.tscn";
+        try
+        {
+            // Register for Control, then overwrite to NCreatureVisuals
+            _sceneTypes[path] = typeof(Control);
+            RegisterSceneType<MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals>(path);
+            Assert(_sceneTypes.TryGetValue(path, out var t) && t == typeof(MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals),
+                "Overwrite registration");
+
+            // Unregister
+            UnregisterSceneType(path);
+            Assert(!_sceneTypes.ContainsKey(path), "Unregister removes path");
+
+            // Unregister again (should not throw)
+            UnregisterSceneType(path);
+            Assert(true, "Double unregister is safe");
+        }
+        catch (Exception e) { Assert(false, $"Overwrite/unregister (threw: {e.Message})"); }
+        finally { _sceneTypes.TryRemove(path, out _); }
+    }
+
+    /// <summary>
+    /// Verify the public query APIs work.
+    /// </summary>
+    private static void TestQueryApis()
+    {
+        Assert(HasFactory<MegaCrit.Sts2.Core.Nodes.Combat.NCreatureVisuals>(), "HasFactory<NCreatureVisuals>");
+        Assert(HasFactory<Control>(), "HasFactory<Control>");
+        Assert(!HasFactory<Sprite2D>(), "!HasFactory<Sprite2D> (no factory registered)");
+
+        const string path = "res://baselib_test/query_test.tscn";
+        _sceneTypes[path] = typeof(Control);
+        Assert(IsRegistered(path), "IsRegistered for known path");
+        Assert(!IsRegistered("res://nonexistent/path.tscn"), "!IsRegistered for unknown path");
+        Assert(!IsRegistered(""), "!IsRegistered for empty path");
+        Assert(!IsRegistered(null!), "!IsRegistered for null path");
+        _sceneTypes.TryRemove(path, out _);
+    }
+
+    private static void AddOwnedChild(Node parent, Node child)
+    {
+        parent.AddChild(child);
+        child.Owner = parent;
+    }
+
     protected interface INodeInfo
     {
         string Path { get; }

--- a/docs/auto_conversion.md
+++ b/docs/auto_conversion.md
@@ -1,0 +1,176 @@
+# Scene Auto-Conversion
+
+Automatically converts Godot scenes with standard root node types (Node2D, Control) into game-specific types (NCreatureVisuals, NEnergyCounter) at instantiation time. Modders can build scenes in the Godot editor using standard nodes and have them work seamlessly when the game calls `Instantiate<T>()`.
+
+## The Problem
+
+When the game calls `PackedScene.Instantiate<NCreatureVisuals>()`, it expects the scene's root node to be an `NCreatureVisuals`. But modders building scenes in the Godot editor can't use game-specific script types as root nodes — those scripts aren't available in the editor. So they use `Node2D` or `Control` as the root, and the cast fails with an `InvalidCastException`.
+
+Harmony can't patch `Instantiate<T>()` directly because it's a generic method and .NET shares native code across reference-type instantiations. Previous attempts to return wrapper classes with explicit cast operators also failed because `Instantiate<T>()` uses an IL `castclass` instruction, which ignores user-defined operators.
+
+## How It Works
+
+The solution patches the **non-generic** `PackedScene.Instantiate(GenEditState)` with a Harmony postfix. Since Godot's generic `Instantiate<T>()` calls the non-generic version internally:
+
+```csharp
+// Godot's actual implementation (from GodotSharp.dll):
+public T Instantiate<T>(GenEditState editState = ...) where T : class
+{
+    return (T)(object)Instantiate(editState);  // cast happens AFTER our postfix
+}
+```
+
+The postfix runs after `Instantiate()` returns but before `Instantiate<T>()` casts the result. If the scene path is registered for auto-conversion, the postfix replaces the Node2D with a proper NCreatureVisuals (or whatever type is registered). The cast then succeeds naturally.
+
+### Step by step
+
+1. Game code calls `scene.Instantiate<NCreatureVisuals>()`
+2. Internally, `Instantiate<T>()` calls `Instantiate()` (non-generic)
+3. Non-generic `Instantiate()` returns a `Node2D` (the scene's actual root type)
+4. **Our Harmony postfix fires** — checks the scene path against the registry
+5. Finds a match, calls `NCreatureVisualsFactory.CreateAndConvert(node2d)`
+6. Factory creates a new `NCreatureVisuals`, transfers children, generates missing marker nodes
+7. Postfix replaces `__result` with the converted `NCreatureVisuals`
+8. Back in `Instantiate<T>()`, the `(T)(object)result` cast succeeds because result IS an NCreatureVisuals
+
+## Usage
+
+### For Custom Characters (automatic)
+
+If you extend `CustomCharacterModel` and set `CustomVisualPath`, the path is auto-registered when your character is created. No extra code needed:
+
+```csharp
+public class MyCharacter : CustomCharacterModel
+{
+    // BaseLib auto-registers this path for NCreatureVisuals conversion
+    public override string? CustomVisualPath => "res://MyMod/scenes/my_character.tscn";
+
+    // Return null so the game's default CreateVisuals() path runs,
+    // which calls Instantiate<NCreatureVisuals>() and triggers auto-conversion.
+    public override NCreatureVisuals? CreateCustomVisuals() => null;
+}
+```
+
+`CustomEnergyCounterPath` is also auto-registered for `NEnergyCounter` conversion.
+
+### For Other Scenes (manual registration)
+
+Register scene paths during your mod's initialization:
+
+```csharp
+using BaseLib.Utils.NodeFactories;
+
+// In your mod's Initialize():
+NodeFactory.RegisterSceneType<NCreatureVisuals>("res://MyMod/scenes/my_monster.tscn");
+NodeFactory.RegisterSceneType<NEnergyCounter>("res://MyMod/scenes/my_energy.tscn");
+NodeFactory.RegisterSceneType<Control>("res://MyMod/scenes/my_ui.tscn");
+```
+
+After registration, any call to `Instantiate<NCreatureVisuals>()` on that scene path will auto-convert.
+
+### Using CreateFromScene Directly
+
+You can also bypass auto-conversion and call the factory explicitly. This is what `CreateCustomVisuals()` does internally when you don't return null:
+
+```csharp
+var visuals = NodeFactory<NCreatureVisuals>.CreateFromScene("res://MyMod/scenes/my_creature.tscn");
+```
+
+Both approaches use the same factory logic. Auto-conversion just makes it transparent for code paths you don't control (Bestiary, GameOverScreen, etc).
+
+## Scene Requirements
+
+Your `.tscn` scene should include the child nodes that the target type expects. For `NCreatureVisuals`:
+
+- **Visuals** (Node2D or Sprite2D) — the visual representation, with `unique_name_in_owner = true`
+- **Bounds** (Control) — clickable area for targeting
+
+The factory will auto-generate missing marker nodes (`CenterPos`, `IntentPos`, `OrbPos`, `TalkPos`) with reasonable defaults based on the Bounds size. But `Visuals` must be provided.
+
+For `NEnergyCounter`, see the existing `NEnergyCounterFactory` for required nodes.
+
+## Public API
+
+```csharp
+// Registration
+NodeFactory.RegisterSceneType<NCreatureVisuals>(scenePath);
+NodeFactory.RegisterSceneType(scenePath, typeof(NCreatureVisuals));
+NodeFactory.UnregisterSceneType(scenePath);
+
+// Queries
+NodeFactory.HasFactory<NCreatureVisuals>();  // true if a factory exists for this type
+NodeFactory.IsRegistered(scenePath);         // true if this path is registered
+
+// Direct factory use (no auto-conversion needed)
+var node = NodeFactory<NCreatureVisuals>.CreateFromScene(scenePath);
+var node = NodeFactory<NCreatureVisuals>.CreateFromScene(packedScene);
+var node = NodeFactory<NCreatureVisuals>.CreateFromResource(texture2d);
+```
+
+## Supported Types
+
+Auto-conversion is available for any type that has a registered `NodeFactory<T>`:
+
+| Type | Factory | Description |
+|------|---------|-------------|
+| `NCreatureVisuals` | `NCreatureVisualsFactory` | Monster and character combat visuals |
+| `NEnergyCounter` | `NEnergyCounterFactory` | Energy counter UI |
+| `Control` | `ControlFactory` | Generic UI elements |
+
+Custom factories can be added by extending `NodeFactory<T>`.
+
+## How It Interacts With Existing Code
+
+### With `CreateFromScene()`
+
+If a scene is both registered for auto-conversion AND used via `CreateFromScene()`, the postfix fires on the internal `Instantiate()` call and converts the node. `CreateFromScene()` then sees `if (n is T t) return t;` is true and returns immediately. Both paths produce the same result.
+
+### With `[GlobalClass]` Scenes
+
+If your scene root already uses a `[GlobalClass]` C# script that extends `NCreatureVisuals`, `Instantiate()` returns the correct type directly. The postfix's `IsAssignableFrom` check passes and it returns without converting. No overhead beyond a dictionary lookup.
+
+### With Vanilla Scenes
+
+Vanilla scenes aren't registered in the scene type dictionary, so the postfix returns immediately after the `TryGetValue` miss. The overhead is one `ConcurrentDictionary.TryGetValue()` call per `Instantiate()` — negligible.
+
+## Thread Safety
+
+- Both the factory registry and scene type registry use `ConcurrentDictionary`
+- The `_isConverting` recursion guard is `[ThreadStatic]` — each thread has its own flag
+- Godot node creation is main-thread in practice, but the system is safe if background asset loading calls `Instantiate`
+
+## Self-Tests
+
+17 self-tests run automatically during `NodeFactory.Init()`:
+
+1. Node2D to NCreatureVisuals conversion (non-generic Instantiate)
+2. **Generic `Instantiate<NCreatureVisuals>()` chain** — the critical test proving the IL castclass works
+3. Node2D to Control conversion
+4. Already-correct-type passthrough (no unnecessary conversion)
+5. Unregistered scene passthrough (no interference)
+6. Exact type verification
+7. Null/empty/whitespace path rejection
+8. Registration overwrite
+9. Unregister + double-unregister safety
+10. HasFactory for registered and unregistered types
+11. IsRegistered for various path states
+
+Results are logged at startup: `[BaseLib] All 17 auto-conversion self-tests passed`
+
+## Known Limitations
+
+- **Scene must be loadable**: The scene path must exist in a loaded PCK or the game's resource filesystem. If `GetScene()` fails, auto-conversion never fires.
+- **No pattern-based registration**: Paths must be registered exactly. There's no wildcard/glob support (e.g., `res://MyMod/creatures/*`).
+- **Factory must exist for target type**: If you register a scene for a type with no factory, a warning is logged and the scene is returned unconverted.
+- **One type per path**: Each scene path maps to exactly one target type. Registering the same path again overwrites the previous type.
+- **Properties not fully copied**: The factory copies common properties (Name, position, scale, modulate, etc.) from the source root to the converted target, but game-type-specific properties set on the source root are lost. Put important configuration on child nodes instead.
+- **No animation auto-setup**: The factory converts the node structure but doesn't create AnimationPlayers or set up animation states. If your creature needs animations, either add an AnimationPlayer to the scene or set it up in code after getting the NCreatureVisuals back.
+- **First-conversion-only logging**: To avoid log spam, only the first conversion per scene path is logged at Info level. Subsequent conversions for the same path are silent.
+
+## Potential Future Improvements
+
+- **Pattern-based registration**: `RegisterScenePattern("res://MyMod/creatures/*", typeof(NCreatureVisuals))` to auto-register all scenes under a directory
+- **CustomMonsterModel abstract class**: Similar to `CustomCharacterModel` but for monsters, with auto-registration of VisualsPath
+- **Auto-detection from scene content**: Detect NCreatureVisuals-compatible scenes by checking for `%Visuals` and `%Bounds` children, without requiring explicit registration
+- **NEnergyCounter generic chain test**: Currently only NCreatureVisuals and Control are tested via the generic `Instantiate<T>()` path
+- **Conversion event hooks**: `NodeFactory.OnConverted += (path, from, to) => ...` for mods that want to post-process converted nodes


### PR DESCRIPTION
## Summary

Patches `PackedScene.Instantiate(GenEditState)` with a Harmony postfix so that registered scenes are auto-converted to game types (`NCreatureVisuals`, `NEnergyCounter`, `Control`) before `Instantiate<T>()`'s IL `castclass` runs.

This solves the fundamental problem that Harmony can't patch generic methods and `castclass` ignores user-defined cast operators — by converting the node at the non-generic level before the cast ever happens.

- Modders can build `.tscn` scenes with standard `Node2D`/`Control` roots in the Godot editor
- Game code that calls `Instantiate<NCreatureVisuals>()` auto-converts transparently
- No `[GlobalClass]` needed, no per-callsite Harmony patches, no programmatic visual builders
- `CustomCharacterModel.CustomVisualPath` and `CustomEnergyCounterPath` are auto-registered

### New files
- `Patches/Content/InstantiatePatch.cs` — Harmony postfix using `TargetMethod()` to disambiguate generic/non-generic overloads
- `docs/auto_conversion.md` — full documentation with usage examples, API reference, limitations, and future improvements

### Modified files
- `Utils/NodeFactories/NodeFactory.cs` — factory registry, scene type registry, `TryAutoConvert`, `CreateAndConvert`, public API (`RegisterSceneType`, `UnregisterSceneType`, `HasFactory`, `IsRegistered`), thread-safe `ConcurrentDictionary`, first-conversion-only logging, 17 self-tests
- `Abstracts/CustomCharacterModel.cs` — auto-registers character scene paths on construction
- API compatibility fixes: `ModManager.LoadedMods`, `mod.wasLoaded`, `ThemeConstants.Label` casing

## How it works

```
Game calls scene.Instantiate<NCreatureVisuals>()
  → Internally calls Instantiate() (non-generic)
  → Our postfix fires, checks scene path registry
  → Finds match, calls NCreatureVisualsFactory.CreateAndConvert(node2d)
  → Replaces __result with converted NCreatureVisuals
  → Back in Instantiate<T>(), castclass succeeds
```

## Test plan

- [x] 17 self-tests run at init (including critical `Instantiate<NCreatureVisuals>()` generic chain test)
- [x] Vanilla gameplay: Ironclad, Silent, Defect — zero exceptions in combat
- [x] HermitMod conversion test: switched from programmatic builder to `.tscn` scene + `CustomVisualPath`, character rendered in combat via auto-conversion
- [x] Unregistered scenes pass through with no overhead beyond a dictionary lookup
- [x] Already-correct-type scenes pass through without conversion
- [x] Thread safety: ConcurrentDictionary for both registries, ThreadStatic recursion guard
- [x] Input validation: null/empty/whitespace paths rejected with warning log