### PR TITLE
Hotfix for #97

### DIFF
--- a/Abstracts/CustomCardModel.cs
+++ b/Abstracts/CustomCardModel.cs
@@ -57,25 +57,35 @@ class CustomCardPortraitPngPath
     {
         if (__instance is not CustomCardModel customCard) return true;
         
-        __result = customCard.CustomPortraitPath;
-        return __result == null;
+        if (customCard.CustomPortraitPath != null) {
+            __result = customCard.CustomPortraitPath;
+        } else {
+            return true;
+        }
+        return false;
     }
 }
 
-[HarmonyPatch(typeof(CardModel), "Portrait", MethodType.Getter)]
+[HarmonyPatch(typeof(CardModel), nameof(CardModel.Portrait), MethodType.Getter)]
 class CustomCardPortrait
 {
     [HarmonyPrefix]
     static bool UseAltTexture(CardModel __instance, ref Texture2D? __result)
     {
         if (__instance is not CustomCardModel customCard) return true;
-        
-        __result = customCard.CustomPortrait ?? ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath);
-        return __result == null;
+
+        if (customCard.CustomPortrait != null) {
+            __result = customCard.CustomPortrait;
+        } else if (customCard.CustomPortraitPath != null) {
+            __result = ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath);
+        } else {
+            return true;
+        }
+        return false;
     }
 }
 
-[HarmonyPatch(typeof(CardModel), "PortraitPath", MethodType.Getter)]
+[HarmonyPatch(typeof(CardModel), nameof(CardModel.PortraitPath), MethodType.Getter)]
 class CustomCardPortraitPath
 {
     [HarmonyPrefix]
@@ -83,11 +93,14 @@ class CustomCardPortraitPath
     {
         if (__instance is not CustomCardModel customCard) return true;
 
-        if (customCard.CustomPortrait == null) {
-            __result = ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath).ResourcePath;
-        } else {
+        if (customCard.CustomPortrait != null) {
             __result = customCard.CustomPortrait.ResourcePath;
+        } else if (customCard.CustomPortraitPath != null) {
+            __result = ResourceLoader.Load<Texture2D>(customCard.CustomPortraitPath).ResourcePath;
+            // Confusingly CustomPortraitPath is a png
+        } else {
+            return true;
         }
-        return __result == null;
+        return false;
     }
 }


### PR DESCRIPTION
Addresses #97 
The logic i copied with the Prefix with `return X == null` breaks down and is confusing with more complicated logic so now im making explicit fixes.
Draft for now to test, but locally it worked for me:
<img width="446" height="620" alt="image" src="https://github.com/user-attachments/assets/2e1e751d-462d-4143-b9d9-e8a507b12516" />
