### PR TITLE
Change `GetLoadedMods()` to `LoadedMods` since API changed

### DIFF
--- a/Patches/Features/ModInteropPatch.cs
+++ b/Patches/Features/ModInteropPatch.cs
@@ -19,7 +19,7 @@ internal class ModInterop
     {
         BaseLibMain.Logger.Info("Generating interop methods and properties");
         
-        _loadedIds = ModManager.GetLoadedMods()
+        _loadedIds = ModManager.LoadedMods
             .Where(mod => mod.manifest != null && mod.assembly != null)
             .ToDictionary(mod => mod.manifest?.id ?? "", mod => mod.assembly);
     }


### PR DESCRIPTION
Fixes #107.

STS2 version 0.99.1 does not have `MegaCrit.Sts2.Core.Modding.ModManager.GetLoadedMods()`; instead, it has this:

```cs
public static IReadOnlyList<Mod> LoadedMods => (IReadOnlyList<Mod>) ModManager._loadedMods;
```

Which causes the game to crash on load with BaseLib, since BaseLib tries to call `GetLoadedMods()`. This change prevents that from happening\*.

\* I don't know how to test this so no guarantees