### PR TITLE
Add Harmony patch dump features and path configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+local.props
+!local.props.template
+
 .godot/
 /android/
 .git/

--- a/BaseLib.csproj
+++ b/BaseLib.csproj
@@ -59,7 +59,7 @@
         <None Include="project.godot" />
         <None Include="README.md" Pack="true" PackagePath="/"/>
         <None Include=".gitignore" />
-        <None Include="local.props" />
+        <None Include="local.props" Condition="Exists('local.props')" Pack="false" CopyToOutputDirectory="Never" />
         <None Include="local.props.template" />
         <None Include="Sts2PathDiscovery.props" />
         <None Include="Notes.txt" />

--- a/BaseLib.csproj
+++ b/BaseLib.csproj
@@ -1,4 +1,6 @@
-﻿<Project Sdk="Godot.NET.Sdk/4.5.1">
+<Project Sdk="Godot.NET.Sdk/4.5.1">
+    <Import Project=".\local.props" Condition="Exists('.\local.props')"/>
+    <Import Project=".\Sts2PathDiscovery.props"/>
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>true</ImplicitUsings>
@@ -33,51 +35,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
-    <!-- OS Detection -->
-    <PropertyGroup>
-        <IsWindows>false</IsWindows>
-        <IsLinux>false</IsLinux>
-        <IsOSX>false</IsOSX>
-        <IsWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))">true</IsWindows>
-        <IsLinux Condition="$([MSBuild]::IsOSPlatform('Linux'))">true</IsLinux>
-        <IsOSX Condition="$([MSBuild]::IsOSPlatform('OSX'))">true</IsOSX>
-    </PropertyGroup>
-
-    <!-- Windows -->
-    <PropertyGroup Condition="'$(IsWindows)' == 'true'">
-        <!-- Try getting uninstall location first -->
-        <Sts2Path Condition="'$(Sts2Path)' == ''">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 2868840', 'InstallLocation', '', RegistryView.Registry64, RegistryView.Registry32))</Sts2Path>
-        <AutoSteamPath>$(registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\steamapps</AutoSteamPath>
-        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == '' and Exists('$(AutoSteamPath)/common/Slay the Spire 2')">$(AutoSteamPath)</SteamLibraryPath>
-        
-        <!-- If on Windows and Slay the Spire 2 is not installed in your default steam library, adjust the following.-->
-        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">C:/Program Files (x86)/Steam/steamapps</SteamLibraryPath>
-        <GodotPath>Z:\Projects\sts2\megadot\MegaDot_v4.5.1-stable_mono_win64.exe</GodotPath>
-        
-        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
-        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_windows_x86_64</Sts2DataDir>
-    </PropertyGroup>
-
-    <!-- Linux -->
-    <PropertyGroup Condition="'$(IsLinux)' == 'true'">
-        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">$(HOME)/.local/share/Steam/steamapps</SteamLibraryPath>
-        <GodotPath Condition="'$(GodotPath)' == ''">$(HOME)/bin/megadot/megadot</GodotPath>
-        
-        
-        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
-        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_linuxbsd_x86_64</Sts2DataDir>
-    </PropertyGroup>
-    <!-- // TODO: Megadot is version 4.5.1, and the game won't load pck if godot is newer. -->
-
-    <!-- macOS // TODO -->
-    <PropertyGroup Condition="'$(IsOSX)' == 'true'">
-        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">$(HOME)/Library/Application Support/Steam/steamapps</SteamLibraryPath>
-        <GodotPath Condition="'$(GodotPath)' == ''">$(HOME)/</GodotPath>
-        
-        
-        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
-        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_macos_x86_64</Sts2DataDir>
-    </PropertyGroup>
+    <!-- Sts2Path / Sts2DataDir: Sts2PathDiscovery.props (+ optional local.props). GodotPath in local.props for .pck export. -->
 
     <ItemGroup>
         <Reference Include="0Harmony">
@@ -101,6 +59,9 @@
         <None Include="project.godot" />
         <None Include="README.md" Pack="true" PackagePath="/"/>
         <None Include=".gitignore" />
+        <None Include="local.props" />
+        <None Include="local.props.template" />
+        <None Include="Sts2PathDiscovery.props" />
         <None Include="Notes.txt" />
         <None Include="export_presets.cfg" />
         <None Include="BaseLib.json" />
@@ -153,6 +114,6 @@
     </Target>
 
     <Target Name="GodotPublishSkipped" AfterTargets="Publish" Condition="'$(GodotPath)' == '' or !Exists('$(GodotPath)')">
-        <Message Text="Skipping Godot .pck export because GodotPath is not configured." Importance="high"/>
+        <Message Text="Skipping Godot .pck export: set GodotPath in local.props — see local.props.template." Importance="high"/>
     </Target>
 </Project>

--- a/BaseLib/localization/eng/settings_ui.json
+++ b/BaseLib/localization/eng/settings_ui.json
@@ -21,5 +21,24 @@
   "BASELIB-LIMITED_LOG_SIZE.hover.desc": "Maximum number of lines retained in the in-game log window.",
 
   "BASELIB-LOG_FONT_SIZE.title": "Log font size",
-  "BASELIB-LOG_FONT_SIZE.hover.desc": "Can also be set with Ctrl+scroll in the log window."
+  "BASELIB-LOG_FONT_SIZE.hover.desc": "Can also be set with Ctrl+scroll in the log window.",
+
+  "BASELIB-HARMONY_DUMP_SECTION.title": "Harmony patch dump",
+
+  "BASELIB-HARMONY_PATCH_DUMP_OUTPUT_PATH.title": "Output file path",
+  "BASELIB-HARMONY_PATCH_DUMP_OUTPUT_PATH.placeholder": "Absolute path or user://… (e.g. user://baselib_harmony_patch_dump.log)",
+  "BASELIB-HARMONY_PATCH_DUMP_OUTPUT_PATH.hover.desc": "Where to write the patch report. Use Browse to pick a file, or type a full path or Godot user:// path.",
+
+  "BASELIB-HARMONY_PATCH_DUMP_ON_FIRST_MAIN_MENU.title": "Dump when main menu first loads",
+  "BASELIB-HARMONY_PATCH_DUMP_ON_FIRST_MAIN_MENU.hover.desc": "Once per game session, after the main menu finishes loading, write the report if the output path is set.",
+
+  "BASELIB-HARMONY_DUMP_BROWSE_FOR_OUTPUT.title": "Choose output file",
+  "BASELIB-HARMONY_DUMP_BROWSE.title": "Browse…",
+  "BASELIB-HARMONY_DUMP_BROWSE_FOR_OUTPUT.hover.desc": "Opens a save dialog and fills the output path above.",
+
+  "BASELIB-HARMONY_DUMP_WRITE_NOW.title": "Write dump now",
+  "BASELIB-HARMONY_DUMP_NOW.title": "Dump now",
+  "BASELIB-HARMONY_DUMP_WRITE_NOW.hover.desc": "Generates the report immediately using the output path. Check the log for success or errors.",
+
+  "BASELIB-HARMONY_DUMP_BROWSE_TITLE.title": "Save Harmony patch dump"
 }

--- a/Config/BaseLibConfig.cs
+++ b/Config/BaseLibConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace BaseLib.Config;
+using BaseLib.Diagnostics;
+using Godot;
+
+namespace BaseLib.Config;
 
 [HoverTipsByDefault]
 internal class BaseLibConfig : SimpleModConfig
@@ -16,6 +19,51 @@ internal class BaseLibConfig : SimpleModConfig
     [SliderRange(8, 48)]
     [SliderLabelFormat("{0:0} px")]
     public static double LogFontSize { get; set; } = 14;
+
+    [ConfigSection("HarmonyDumpSection")]
+    [ConfigTextInput(TextInputPreset.Anything, MaxLength = 1024)]
+    public static string HarmonyPatchDumpOutputPath { get; set; } = "";
+
+    public static bool HarmonyPatchDumpOnFirstMainMenu { get; set; }
+
+    [ConfigButton("HarmonyDumpBrowse")]
+    public static void HarmonyDumpBrowseForOutput(ModConfig config)
+    {
+        var tree = Engine.GetMainLoop() as SceneTree;
+        if (tree?.Root == null)
+        {
+            BaseLibMain.Logger.Warn("[HarmonyDump] Cannot open file dialog: SceneTree root is not available.");
+            return;
+        }
+
+        var dialog = new FileDialog
+        {
+            Title = GetBaseLibLabelText("HarmonyDumpBrowseTitle"),
+            FileMode = FileDialog.FileModeEnum.SaveFile,
+            Access = FileDialog.AccessEnum.Filesystem,
+            CurrentFile = "baselib_harmony_patch_dump.log",
+        };
+        dialog.AddFilter("*.log", "Log");
+        dialog.AddFilter("*.txt", "Text");
+
+        dialog.FileSelected += path =>
+        {
+            HarmonyPatchDumpOutputPath = path;
+            config.Save();
+            config.ConfigReloaded();
+            dialog.QueueFree();
+        };
+        dialog.Canceled += dialog.QueueFree;
+
+        tree.Root.AddChild(dialog);
+        dialog.PopupCenteredRatio(0.55f);
+    }
+
+    [ConfigButton("HarmonyDumpNow")]
+    public static void HarmonyDumpWriteNow(ModConfig _)
+    {
+        HarmonyPatchDumpCoordinator.TryManualDumpFromSettings();
+    }
 
     [ConfigHideInUI] public static int LastLogLevel { get; set; } = 3; // Default to Info
     [ConfigHideInUI] public static bool LogUseRegex { get; set; } = false;

--- a/Diagnostics/HarmonyPatchDumpCoordinator.cs
+++ b/Diagnostics/HarmonyPatchDumpCoordinator.cs
@@ -1,0 +1,50 @@
+using BaseLib.Config;
+
+namespace BaseLib.Diagnostics;
+
+/// <summary>
+///     Manual and first-main-menu Harmony patch dumps using <see cref="BaseLibConfig" />.
+/// </summary>
+internal static class HarmonyPatchDumpCoordinator
+{
+    private static int _autoDumpIssuedForSession;
+
+    /// <summary>
+    ///     Deferred from <see cref="MegaCrit.Sts2.Core.Nodes.Screens.MainMenu.NMainMenu._Ready" />; at most once per
+    ///     process when enabled.
+    /// </summary>
+    internal static void TryAutoDumpOnFirstMainMenu()
+    {
+        if (!BaseLibConfig.HarmonyPatchDumpOnFirstMainMenu)
+            return;
+
+        if (Interlocked.CompareExchange(ref _autoDumpIssuedForSession, 1, 0) != 0)
+            return;
+
+        TryDumpToConfiguredPath(BaseLibConfig.HarmonyPatchDumpOutputPath, "[HarmonyDump][Auto]");
+    }
+
+    internal static void TryManualDumpFromSettings()
+    {
+        TryDumpToConfiguredPath(BaseLibConfig.HarmonyPatchDumpOutputPath, "[HarmonyDump][Manual]");
+    }
+
+    private static void TryDumpToConfiguredPath(string rawPath, string logPrefix)
+    {
+        var resolved = HarmonyPatchDumpWriter.TryResolveFilesystemPath(rawPath);
+        if (string.IsNullOrEmpty(resolved))
+        {
+            BaseLibMain.Logger.Warn(
+                $"{logPrefix} Output path is empty or invalid. Set a path in BaseLib mod config (or use Browse).");
+            return;
+        }
+
+        if (!HarmonyPatchDumpWriter.TryWrite(resolved, out var err))
+        {
+            BaseLibMain.Logger.Warn($"{logPrefix} Failed to write dump: {err}");
+            return;
+        }
+
+        BaseLibMain.Logger.Info($"{logPrefix} Wrote Harmony patch dump to: {resolved}");
+    }
+}

--- a/Diagnostics/HarmonyPatchDumpWriter.cs
+++ b/Diagnostics/HarmonyPatchDumpWriter.cs
@@ -1,0 +1,190 @@
+using System.Reflection;
+using System.Text;
+using Godot;
+using HarmonyLib;
+using FileAccess = System.IO.FileAccess;
+
+namespace BaseLib.Diagnostics;
+
+/// <summary>
+///     Writes a UTF-8 text report of all Harmony-patched methods (prefix/postfix/transpiler/finalizer).
+/// </summary>
+internal static class HarmonyPatchDumpWriter
+{
+    /// <summary>
+    ///     Resolves <c>user://</c> / <c>res://</c> via Godot and returns an absolute filesystem path.
+    /// </summary>
+    internal static string? TryResolveFilesystemPath(string rawPath)
+    {
+        if (string.IsNullOrWhiteSpace(rawPath))
+            return null;
+
+        var trimmed = rawPath.Trim();
+        if (trimmed.StartsWith("user://", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("res://", StringComparison.OrdinalIgnoreCase))
+            return ProjectSettings.GlobalizePath(trimmed);
+
+        return Path.GetFullPath(trimmed);
+    }
+
+    internal static bool TryWrite(string filesystemPath, out string? errorMessage)
+    {
+        errorMessage = null;
+        try
+        {
+            var dir = Path.GetDirectoryName(filesystemPath);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            using var fileStream =
+                new FileStream(filesystemPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+            using var streamWriter = new StreamWriter(fileStream, Encoding.UTF8);
+            WriteReport(streamWriter);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            errorMessage = ex.Message;
+            return false;
+        }
+    }
+
+    private static void WriteReport(StreamWriter streamWriter)
+    {
+        streamWriter.WriteLine("=======================================================");
+        streamWriter.WriteLine("===          Harmony Patch Dump Report             ===");
+        streamWriter.WriteLine("=======================================================");
+        streamWriter.WriteLine($"Generated at: {DateTime.Now:O}");
+        streamWriter.WriteLine($"User data dir: {OS.GetUserDataDir()}");
+        streamWriter.WriteLine("=======================================================");
+        streamWriter.WriteLine();
+
+        var allPatchedMethods = Harmony.GetAllPatchedMethods()
+            .OrderBy(m => m.DeclaringType?.FullName ?? "Unknown")
+            .ThenBy(m => m.Name)
+            .ToList();
+
+        var methodCount = 0;
+        var totalPrefixes = 0;
+        var totalPostfixes = 0;
+        var totalTranspilers = 0;
+        var totalFinalizers = 0;
+
+        foreach (var patchedMethod in allPatchedMethods)
+        {
+            methodCount++;
+            var counts = LogPatchedMethodInfo(patchedMethod, streamWriter);
+            totalPrefixes += counts.prefixes;
+            totalPostfixes += counts.postfixes;
+            totalTranspilers += counts.transpilers;
+            totalFinalizers += counts.finalizers;
+            streamWriter.WriteLine();
+        }
+
+        streamWriter.WriteLine("=======================================================");
+        streamWriter.WriteLine("===                   Summary                      ===");
+        streamWriter.WriteLine("=======================================================");
+        streamWriter.WriteLine($"Total Patched Methods:  {methodCount}");
+        streamWriter.WriteLine($"  - Prefix patches:     {totalPrefixes}");
+        streamWriter.WriteLine($"  - Postfix patches:    {totalPostfixes}");
+        streamWriter.WriteLine($"  - Transpiler patches: {totalTranspilers}");
+        streamWriter.WriteLine($"  - Finalizer patches:  {totalFinalizers}");
+        streamWriter.WriteLine(
+            $"  - Total patches:      {totalPrefixes + totalPostfixes + totalTranspilers + totalFinalizers}");
+        streamWriter.WriteLine("=======================================================");
+    }
+
+    private static (int prefixes, int postfixes, int transpilers, int finalizers) LogPatchedMethodInfo(
+        MethodBase methodBase, StreamWriter streamWriter)
+    {
+        var patchInfo = Harmony.GetPatchInfo(methodBase);
+        if (patchInfo == null) return (0, 0, 0, 0);
+
+        var declaringType = methodBase.DeclaringType?.FullName ?? "Unknown";
+        var methodSignature = GetMethodSignature(methodBase);
+        var returnType = methodBase is MethodInfo mi ? mi.ReturnType.Name : "void";
+
+        streamWriter.WriteLine($"┌─ [{declaringType}]");
+        streamWriter.WriteLine($"│  Method: {returnType} {methodSignature}");
+        streamWriter.WriteLine("│");
+
+        var prefixCount = 0;
+        var postfixCount = 0;
+        var transpilerCount = 0;
+        var finalizerCount = 0;
+
+        if (patchInfo.Prefixes.Count > 0)
+        {
+            streamWriter.WriteLine($"│  ├─ Prefixes ({patchInfo.Prefixes.Count}):");
+            foreach (var patch in patchInfo.Prefixes.OrderBy(p => p.priority).ThenBy(p => p.owner))
+            {
+                streamWriter.WriteLine($"│  │  {FormatPatchInfo(patch)}");
+                prefixCount++;
+            }
+        }
+
+        if (patchInfo.Postfixes.Count > 0)
+        {
+            streamWriter.WriteLine($"│  ├─ Postfixes ({patchInfo.Postfixes.Count}):");
+            foreach (var patch in patchInfo.Postfixes.OrderBy(p => p.priority).ThenBy(p => p.owner))
+            {
+                streamWriter.WriteLine($"│  │  {FormatPatchInfo(patch)}");
+                postfixCount++;
+            }
+        }
+
+        if (patchInfo.Transpilers.Count > 0)
+        {
+            streamWriter.WriteLine($"│  ├─ Transpilers ({patchInfo.Transpilers.Count}):");
+            foreach (var patch in patchInfo.Transpilers.OrderBy(p => p.priority).ThenBy(p => p.owner))
+            {
+                streamWriter.WriteLine($"│  │  {FormatPatchInfo(patch)}");
+                transpilerCount++;
+            }
+        }
+
+        if (patchInfo.Finalizers.Count > 0)
+        {
+            streamWriter.WriteLine($"│  └─ Finalizers ({patchInfo.Finalizers.Count}):");
+            foreach (var patch in patchInfo.Finalizers.OrderBy(p => p.priority).ThenBy(p => p.owner))
+            {
+                streamWriter.WriteLine($"│     {FormatPatchInfo(patch)}");
+                finalizerCount++;
+            }
+        }
+
+        streamWriter.WriteLine("└─────────────────────────────────────────────────────────────────");
+
+        return (prefixCount, postfixCount, transpilerCount, finalizerCount);
+    }
+
+    private static string GetMethodSignature(MethodBase methodBase)
+    {
+        var parameters = methodBase.GetParameters();
+        var paramString = string.Join(", ", parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
+        return $"{methodBase.Name}({paramString})";
+    }
+
+    private static string FormatPatchInfo(Patch patch)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"├─ [Priority: {patch.priority}] ");
+        sb.Append($"[{patch.owner}] ");
+        var patchClass = patch.PatchMethod.DeclaringType?.FullName ?? "Unknown";
+        var patchMethodName = patch.PatchMethod.Name;
+        sb.Append($"{patchClass}.{patchMethodName}");
+
+        try
+        {
+            var moduleName = Path.GetFileName(patch.PatchMethod.Module.FullyQualifiedName);
+            if (!string.IsNullOrEmpty(moduleName) && moduleName != "<Unknown>")
+                sb.Append($" (from {moduleName})");
+        }
+        catch
+        {
+            // ignored
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Diagnostics/HarmonyPatchDumpWriter.cs
+++ b/Diagnostics/HarmonyPatchDumpWriter.cs
@@ -20,11 +20,18 @@ internal static class HarmonyPatchDumpWriter
             return null;
 
         var trimmed = rawPath.Trim();
-        if (trimmed.StartsWith("user://", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.StartsWith("res://", StringComparison.OrdinalIgnoreCase))
-            return ProjectSettings.GlobalizePath(trimmed);
+        try
+        {
+            if (trimmed.StartsWith("user://", StringComparison.OrdinalIgnoreCase) ||
+                trimmed.StartsWith("res://", StringComparison.OrdinalIgnoreCase))
+                return ProjectSettings.GlobalizePath(trimmed);
 
-        return Path.GetFullPath(trimmed);
+            return Path.GetFullPath(trimmed);
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     internal static bool TryWrite(string filesystemPath, out string? errorMessage)

--- a/Patches/Utils/HarmonyPatchDumpMainMenuPatch.cs
+++ b/Patches/Utils/HarmonyPatchDumpMainMenuPatch.cs
@@ -1,0 +1,21 @@
+using BaseLib.Diagnostics;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.MainMenu;
+
+namespace BaseLib.Patches.Utils;
+
+/// <summary>
+///     After main menu is ready, optionally dump Harmony patch info once per session (deferred).
+/// </summary>
+[HarmonyPatch(typeof(NMainMenu), nameof(NMainMenu._Ready))]
+public static class HarmonyPatchDumpMainMenuPatch
+{
+    /// <summary>
+    ///     After main menu is ready, optionally dump Harmony patch info once per session (deferred).
+    /// </summary>
+    public static void Postfix()
+    {
+        Callable.From(HarmonyPatchDumpCoordinator.TryAutoDumpOnFirstMainMenu).CallDeferred();
+    }
+}

--- a/Sts2PathDiscovery.props
+++ b/Sts2PathDiscovery.props
@@ -1,0 +1,43 @@
+<Project>
+    <!--
+      Fills Sts2Path and Sts2DataDir when not set (e.g. no local.props).
+      Override via local.props or MSBuild /p:Sts2Path=...
+    -->
+    <!-- OS Detection -->
+    <PropertyGroup>
+        <IsWindows>false</IsWindows>
+        <IsLinux>false</IsLinux>
+        <IsOSX>false</IsOSX>
+        <IsWindows Condition="$([MSBuild]::IsOSPlatform('Windows'))">true</IsWindows>
+        <IsLinux Condition="$([MSBuild]::IsOSPlatform('Linux'))">true</IsLinux>
+        <IsOSX Condition="$([MSBuild]::IsOSPlatform('OSX'))">true</IsOSX>
+    </PropertyGroup>
+
+    <!-- Windows -->
+    <PropertyGroup Condition="'$(IsWindows)' == 'true'">
+        <!-- Try getting uninstall location first -->
+        <Sts2Path Condition="'$(Sts2Path)' == ''">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 2868840', 'InstallLocation', '', RegistryView.Registry64, RegistryView.Registry32))</Sts2Path>
+        <AutoSteamPath>$(registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\steamapps</AutoSteamPath>
+        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == '' and Exists('$(AutoSteamPath)/common/Slay the Spire 2')">$(AutoSteamPath)</SteamLibraryPath>
+        
+        <!-- If on Windows and Slay the Spire 2 is not installed in your default steam library, adjust the following.-->
+        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">C:/Program Files (x86)/Steam/steamapps</SteamLibraryPath>
+        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
+        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_windows_x86_64</Sts2DataDir>
+    </PropertyGroup>
+
+    <!-- Linux -->
+    <PropertyGroup Condition="'$(IsLinux)' == 'true'">
+        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">$(HOME)/.local/share/Steam/steamapps</SteamLibraryPath>
+        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
+        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_linuxbsd_x86_64</Sts2DataDir>
+    </PropertyGroup>
+    <!-- // TODO: Megadot is version 4.5.1, and the game won't load pck if godot is newer. -->
+
+    <!-- macOS // TODO -->
+    <PropertyGroup Condition="'$(IsOSX)' == 'true'">
+        <SteamLibraryPath Condition="'$(SteamLibraryPath)' == ''">$(HOME)/Library/Application Support/Steam/steamapps</SteamLibraryPath>
+        <Sts2Path Condition="'$(Sts2Path)' == ''">$(SteamLibraryPath)/common/Slay the Spire 2</Sts2Path>
+        <Sts2DataDir Condition="'$(Sts2DataDir)' == ''">$(Sts2Path)/data_sts2_macos_x86_64</Sts2DataDir>
+    </PropertyGroup>
+</Project>

--- a/local.props.template
+++ b/local.props.template
@@ -1,0 +1,19 @@
+<Project>
+    <!--
+      Copy this file to local.props (gitignored) and adjust paths for your machine.
+
+      If you omit local.props entirely, Sts2PathDiscovery.props will try:
+      - Windows: Steam uninstall registry (App 2868840), then %SteamPath%\steamapps, then Program Files (x86)\Steam\steamapps
+      - Linux:  ~/.local/share/Steam/steamapps
+      - macOS:  ~/Library/Application Support/Steam/steamapps
+
+      Godot / MegaDot is not auto-detected; set GodotPath to export .pck on publish, or leave unset to skip export.
+    -->
+    <PropertyGroup>
+        <Sts2Path>Path\To\SteamLibrary\steamapps\common\Slay the Spire 2</Sts2Path>
+        <!-- Optional: override managed data folder (default is OS-specific under Sts2Path) -->
+        <!-- <Sts2DataDir>$(Sts2Path)\data_sts2_windows_x86_64</Sts2DataDir> -->
+        <!-- Optional: MegaDot / Godot 4.5.1 mono executable used for --export-pack -->
+        <!-- <GodotPath>Z:\Projects\sts2\megadot\MegaDot_v4.5.1-stable_mono_win64.exe</GodotPath> -->
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
This pull request introduces a new feature for generating Harmony patch dump reports and refactors project configuration to simplify OS-specific path handling. The main additions are a user-accessible option to generate a detailed report of all Harmony patches, including UI integration, and a cleaner, more modular approach for configuring game paths via MSBuild property files.

**Harmony Patch Dump Feature:**

* Added new config options and UI buttons in `BaseLibConfig` to set the output path, trigger a dump immediately, or dump automatically after the main menu loads, including file browsing support and user-friendly descriptions (`Config/BaseLibConfig.cs`, `BaseLib/localization/eng/settings_ui.json`). [[1]](diffhunk://#diff-95f68de4c8ca1515de71ece42340c1c61b58a75ea10181daea83d0702394f788R23-R67) [[2]](diffhunk://#diff-d299702d0f025645435ef3eaea40e7467df006f2fca480f02533fb92d12aa362L24-R43)
* Implemented `HarmonyPatchDumpCoordinator` and `HarmonyPatchDumpWriter` to generate a comprehensive, human-readable report of all Harmony-patched methods, with support for Godot's `user://` and `res://` paths (`Diagnostics/HarmonyPatchDumpCoordinator.cs`, `Diagnostics/HarmonyPatchDumpWriter.cs`). [[1]](diffhunk://#diff-05dfcdc1abebdfd9de38af06e660360febe58d02d9717277c2bbac934ceed9d2R1-R50) [[2]](diffhunk://#diff-53ce61a21e39ddccc6f6d959c1968cb0c9c9252d05cb350bfba5a26aca2121f7R1-R190)
* Added a patch to the main menu's `_Ready` method to trigger the automatic dump once per session if enabled (`Patches/Utils/HarmonyPatchDumpMainMenuPatch.cs`).

**Project Configuration Refactor:**

* Moved all OS-specific path detection logic into a new, dedicated `Sts2PathDiscovery.props` file and added a `local.props.template` for user overrides, cleaning up `BaseLib.csproj` and making configuration more maintainable (`Sts2PathDiscovery.props`, `local.props.template`, `BaseLib.csproj`). [[1]](diffhunk://#diff-3e24d5dbbe3a0af22401af9e0bc9cfa8c0d5d0451483f88a9125ac6118adaae5R1-R43) [[2]](diffhunk://#diff-22814f60e9a6781fae5a7ea2bc4315676c46eedb1bb27e42721ced8466031d01R1-R19) [[3]](diffhunk://#diff-90bd074a719307e97e716031a451db8094d6cfa407c463633b6fc0c3bff0535fL1-R3) [[4]](diffhunk://#diff-90bd074a719307e97e716031a451db8094d6cfa407c463633b6fc0c3bff0535fL36-R38) [[5]](diffhunk://#diff-90bd074a719307e97e716031a451db8094d6cfa407c463633b6fc0c3bff0535fR62-R64)
* Updated the publish target message to guide users to set `GodotPath` in `local.props` if not configured (`BaseLib.csproj`).