### PR TITLE
Mod config: allow int and float for Slider

### DIFF
--- a/BaseLibScenes/NLogWindow.cs
+++ b/BaseLibScenes/NLogWindow.cs
@@ -76,7 +76,7 @@ public partial class NLogWindow : Window
         _regexButton.ButtonPressed = BaseLibConfig.LogUseRegex;
         _inverseButton.ButtonPressed = BaseLibConfig.LogInvertFilter;
         _filterInput.Text = BaseLibConfig.LogLastFilter;
-        _currentFontSize = (int)BaseLibConfig.LogFontSize;
+        _currentFontSize = BaseLibConfig.LogFontSize;
 
         _filterInput.TextChanged += (_) => { _settingChanged = true; UpdateFilter(); };
         _regexButton.Toggled += (_) => { _settingChanged = true; UpdateFilter(); };
@@ -244,7 +244,7 @@ public partial class NLogWindow : Window
 
     private static void EnsureLogLimit()
     {
-        int configuredLimit = (int)BaseLibConfig.LimitedLogSize;
+        int configuredLimit = BaseLibConfig.LimitedLogSize;
         if (_log.Limit == configuredLimit) return;
 
         _log.SetLimit(configuredLimit);
@@ -260,7 +260,7 @@ public partial class NLogWindow : Window
     }
 
     private void ChangeFontSize(int deltaPx) =>
-        SetFontSize((int)Mathf.Clamp(BaseLibConfig.LogFontSize + deltaPx, 8, 48));
+        SetFontSize(Math.Clamp(BaseLibConfig.LogFontSize + deltaPx, 8, 48));
 
     private void SetFontSize(int newSize, bool save = true)
     {

--- a/Config/BaseLibConfig.cs
+++ b/Config/BaseLibConfig.cs
@@ -14,11 +14,11 @@ internal class BaseLibConfig : SimpleModConfig
 
     [SliderRange(128, 2048, 64)]
     [SliderLabelFormat("{0:0} lines")]
-    public static double LimitedLogSize { get; set; } = 256;
+    public static int LimitedLogSize { get; set; } = 256;
 
     [SliderRange(8, 48)]
     [SliderLabelFormat("{0:0} px")]
-    public static double LogFontSize { get; set; } = 14;
+    public static int LogFontSize { get; set; } = 14;
 
     [ConfigSection("HarmonyDumpSection")]
     [ConfigTextInput(TextInputPreset.Anything, MaxLength = 1024)]

--- a/Config/ConfigAttributes.cs
+++ b/Config/ConfigAttributes.cs
@@ -13,6 +13,7 @@ public class ConfigSectionAttribute(string name) : Attribute
 
 /// <summary>
 /// Specifies a range and step for a slider. Negative numbers are supported, as are noninteger numbers.<br/>
+/// Supported property types: <see cref="int"/>, <see cref="float"/>, <see cref="double"/>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 public class SliderRangeAttribute : Attribute

--- a/Config/SimpleModConfig.cs
+++ b/Config/SimpleModConfig.cs
@@ -161,8 +161,8 @@ public class SimpleModConfig : ModConfig
 
         NConfigOptionRow optionRow;
         if (propertyType == typeof(bool)) optionRow = CreateToggleOption(property);
-        else if (propertyType == typeof(double)) optionRow = CreateSliderOption(property);
         else if (propertyType == typeof(string)) optionRow = CreateLineEditOption(property);
+        else if (NConfigSlider.SupportedTypes.Contains(propertyType)) optionRow = CreateSliderOption(property);
         else if (propertyType.IsEnum) optionRow = CreateDropdownOption(property);
         else throw new NotSupportedException($"Type {propertyType.FullName} is not supported by SimpleModConfig.");
 

--- a/Config/UI/NConfigSlider.cs
+++ b/Config/UI/NConfigSlider.cs
@@ -13,6 +13,7 @@ namespace BaseLib.Config.UI;
 // We don't inherit from NSettingsSlider because it's too rigid (forces % in the format, forces step of 5, fixed width)
 public partial class NConfigSlider : Control
 {
+    public static readonly Type[] SupportedTypes = [typeof(int), typeof(float), typeof(double)];
     private ModConfig? _config;
     private PropertyInfo? _property;
     private string _displayFormat = "{0}";
@@ -56,6 +57,8 @@ public partial class NConfigSlider : Control
     public double MaxValue { get; private set; }
     public double Step => _slider.Step;
 
+    private static bool IsInteger(double value) => Math.Abs(value - Math.Round(value)) < 1e-6;
+
     /// <summary>
     /// Updates the slider's limits (and optionally step) atomically, ensuring no issues where e.g. min > max occur,
     /// even briefly.<br/>
@@ -68,15 +71,34 @@ public partial class NConfigSlider : Control
         if (min >= max)
             throw new ArgumentException($"Invalid slider range: min ({min}) must be less than max ({max}).");
 
+        if (_property?.PropertyType == typeof(int))
+        {
+            if (!IsInteger(min) || !IsInteger(max))
+                throw new ArgumentException("Invalid slider values: min and max must be integers for property type int");
+
+            min = Math.Round(min);
+            max = Math.Round(max);
+
+            if (step.HasValue)
+            {
+                if (!IsInteger(step.Value))
+                    throw new ArgumentException("Invalid slider values: step must be integer for property type int");
+
+                step = Math.Round(step.Value);
+            }
+        }
+
         // We use an offset to enable negative value support in NSlider
         var currentRealValue = _slider.Value + MinValue;
 
         MinValue = min;
         MaxValue = max;
-        if (step != null) _slider.Step = step.Value;
 
-        // _slider.MinValue is always 0, so we don't touch it here even if _realMin changes
+        // The internal NSlider does not support negative numbers, so we force it to run from 0 and up, and handle the
+        // "real" values manually
+        _slider.MinValue = 0;
         _slider.MaxValue = MaxValue - MinValue;
+        if (step != null) _slider.Step = step.Value;
         RecalculateMinRepeatDelay();
 
         // NSlider.SetValueWithoutAnimation crashes unless its _Ready has executed, but if SetRange is called prior
@@ -111,45 +133,34 @@ public partial class NConfigSlider : Control
         Connect(Godot.Control.SignalName.FocusEntered, Callable.From(OnFocus));
         Connect(Godot.Control.SignalName.FocusExited, Callable.From(OnUnfocus));
 
+        _config!.OnConfigReloaded += SetFromProperty;
+
         _fullyInitialized = true;
     }
 
     public void Initialize(ModConfig modConfig, PropertyInfo property)
     {
-        if (property.PropertyType != typeof(double))
-            throw new ArgumentException("Attempted to assign NConfigSlider a non-double property");
+        if (!SupportedTypes.Contains(property.PropertyType))
+            throw new ArgumentException("Attempted to initialize NConfigSlider with an unsupported property type. " +
+                                        $"Supported types: {string.Join<Type>(", ", SupportedTypes)}");
 
         _config = modConfig;
         _property = property;
 
-        var rangeAttr = property.GetCustomAttribute<SliderRangeAttribute>();
         var formatAttr = property.GetCustomAttribute<SliderLabelFormatAttribute>();
+        _displayFormat = formatAttr?.Format ?? "{0}";
 
+        var rangeAttr = property.GetCustomAttribute<SliderRangeAttribute>();
         var min = rangeAttr?.Min ?? 0;
         var max = rangeAttr?.Max ?? 100;
         var step = rangeAttr?.Step ?? 1;
-        _displayFormat = formatAttr?.Format ?? "{0}";
-
-        if (min >= max)
-            throw new ArgumentException($"Invalid slider range: min ({min}) must be less than max ({max}).");
-
-        MinValue = min;
-        MaxValue = max;
-
-        // Force the internal Godot NSlider to run from 0 upwards, since it does not support negative numbers
-        _slider.MinValue = 0;
-        _slider.MaxValue = MaxValue - MinValue;
-        _slider.Step = step;
-
-        RecalculateMinRepeatDelay();
-
-        _config.OnConfigReloaded += SetFromProperty;
+        SetRange(min, max, step);
     }
 
     private void SetFromProperty()
     {
-        var propValue = (double)_property!.GetValue(null)!;
-        SetValue(propValue);
+        var rawValue = _property!.GetValue(null)!;
+        SetValue(Convert.ToDouble(rawValue));
     }
 
     private void SetValue(double value)
@@ -160,7 +171,7 @@ public partial class NConfigSlider : Control
 
         // Clamp always returns one of its parameters, so exactness isn't an issue here
         // ReSharper disable once CompareOfFloatsByEqualityOperator
-        if (value != clampedValue) _property?.SetValue(null, clampedValue);
+        if (value != clampedValue) _property?.SetValue(null, Convert.ChangeType(clampedValue, _property.PropertyType));
     }
 
     private void OnValueChanged(double proxyValue)
@@ -175,7 +186,7 @@ public partial class NConfigSlider : Control
             realValue = Math.Round(realValue, decimalPlaces);
         }
 
-        _property?.SetValue(null, realValue);
+        _property?.SetValue(null, Convert.ChangeType(realValue, _property.PropertyType));
         _config?.Changed();
         UpdateLabel(realValue);
     }


### PR DESCRIPTION
Makes for more convenient usage, especially for integers. 

Adding `long` support would be trivial, but feels pointless; you can't select a value above 2 billion with a slider anyhow.