### PR TITLE
refactor(DynamicVar): make WithUpgrade and WithTooltip preserve concrete type

### DIFF
--- a/Extensions/DynamicVarExtensions.cs
+++ b/Extensions/DynamicVarExtensions.cs
@@ -18,7 +18,7 @@ public static class DynamicVarExtensions
     public static readonly SpireField<DynamicVar, Func<IHoverTip>> DynamicVarTips = new(() => null);
     public static readonly SpireField<DynamicVar, decimal?> DynamicVarUpgrades = new(() => null);
 
-    public static DynamicVar WithUpgrade(this DynamicVar dynamicVar, decimal upgradeValue)
+    public static TDynamicVar WithUpgrade<TDynamicVar>(this TDynamicVar dynamicVar, decimal upgradeValue) where TDynamicVar : DynamicVar
     {
         if (upgradeValue != 0) DynamicVarUpgrades[dynamicVar] = upgradeValue;
         return dynamicVar;
@@ -53,7 +53,7 @@ public static class DynamicVarExtensions
     /// The key will be the variable's name, with a mod prefix added, in the form of "PREFIX-NAME" (all capitalized).
     /// </summary>
     /// <returns></returns>
-    public static DynamicVar WithTooltip(this DynamicVar var, string? locKey = null, string locTable = "static_hover_tips")
+    public static TDynamicVar WithTooltip<TDynamicVar>(this TDynamicVar var, string? locKey = null, string locTable = "static_hover_tips") where TDynamicVar : DynamicVar
     {
         string key = locKey ?? var.GetType().GetPrefix() + StringHelper.Slugify(var.Name);
 


### PR DESCRIPTION
Changed both extension methods to be generic with a `TDynamicVar : DynamicVar` constraint, allowing them to return the original concrete type instead of the base `DynamicVar` type.

This enables fluent chaining without losing type information:

```csharp
// Before: returns DynamicVar, need explicit cast or lose type
DamageVar dmg = new DamageVar(6).WithUpgrade(3); // ❌ cannot convert

// After: returns TDynamicVar (DamageVar in this case)
DamageVar dmg = new DamageVar(6).WithUpgrade(3); // ✅ works
```