### PR TITLE
Add custom card outline highlighting and registry system

### DIFF
--- a/Hooks/ModCardHandOutlinePatchHelper.cs
+++ b/Hooks/ModCardHandOutlinePatchHelper.cs
@@ -39,15 +39,15 @@ internal static class ModCardHandOutlinePatchHelper
         if (force)
             highlight.AnimShow();
 
-        highlight.Modulate = rule.Color;
+        highlight.Modulate = rule.ResolveColor(model);
     }
 
-    internal static void ApplyFlash(NHandCardHolder holder, ModCardHandOutlineRule rule)
+    internal static void ApplyFlash(NHandCardHolder holder, CardModel model, ModCardHandOutlineRule rule)
     {
         if (AccessTools.Field(typeof(NHandCardHolder), "_flash")?.GetValue(holder) is not Control flash ||
             !GodotObject.IsInstanceValid(flash))
             return;
 
-        flash.Modulate = rule.Color;
+        flash.Modulate = rule.ResolveColor(model);
     }
 }

--- a/Hooks/ModCardHandOutlinePatchHelper.cs
+++ b/Hooks/ModCardHandOutlinePatchHelper.cs
@@ -1,0 +1,53 @@
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
+
+namespace BaseLib.Hooks;
+
+internal static class ModCardHandOutlinePatchHelper
+{
+    internal static bool TryGetRule(NHandCardHolder holder, out CardModel model, out ModCardHandOutlineRule rule)
+    {
+        model = null!;
+        rule = default;
+
+        if (!holder.IsNodeReady() || holder.CardNode?.Model is not { } m)
+            return false;
+
+        var evaluated = ModCardHandOutlineRegistry.EvaluateBest(m);
+        if (evaluated is not { } r)
+            return false;
+
+        model = m;
+        rule = r;
+        return true;
+    }
+
+    internal static void ApplyHighlight(NHandCardHolder holder, CardModel model, ModCardHandOutlineRule rule)
+    {
+        if (CombatManager.Instance is not { IsInProgress: true })
+            return;
+
+        var vanillaShow = model.CanPlay() || model.ShouldGlowRed || model.ShouldGlowGold;
+        var force = rule.VisibleWhenUnplayable && !vanillaShow;
+        if (!vanillaShow && !force)
+            return;
+
+        var highlight = holder.CardNode!.CardHighlight;
+        if (force)
+            highlight.AnimShow();
+
+        highlight.Modulate = rule.Color;
+    }
+
+    internal static void ApplyFlash(NHandCardHolder holder, ModCardHandOutlineRule rule)
+    {
+        if (AccessTools.Field(typeof(NHandCardHolder), "_flash")?.GetValue(holder) is not Control flash ||
+            !GodotObject.IsInstanceValid(flash))
+            return;
+
+        flash.Modulate = rule.Color;
+    }
+}

--- a/Hooks/ModCardHandOutlinePatchHelper.cs
+++ b/Hooks/ModCardHandOutlinePatchHelper.cs
@@ -8,12 +8,12 @@ namespace BaseLib.Hooks;
 
 internal static class ModCardHandOutlinePatchHelper
 {
-    internal static bool TryGetRule(NHandCardHolder holder, out CardModel model, out ModCardHandOutlineRule rule)
+    internal static bool TryGetRule(NHandCardHolder? holder, out CardModel model, out ModCardHandOutlineRule rule)
     {
         model = null!;
         rule = default;
 
-        if (!holder.IsNodeReady() || holder.CardNode?.Model is not { } m)
+        if (!TryGetCardModel(holder, out var m))
             return false;
 
         var evaluated = ModCardHandOutlineRegistry.EvaluateBest(m);
@@ -25,29 +25,110 @@ internal static class ModCardHandOutlinePatchHelper
         return true;
     }
 
-    internal static void ApplyHighlight(NHandCardHolder holder, CardModel model, ModCardHandOutlineRule rule)
+    internal static void ApplyHighlight(NHandCardHolder? holder, CardModel model, ModCardHandOutlineRule rule)
     {
-        if (CombatManager.Instance is not { IsInProgress: true })
+        if (CombatManager.Instance is not { IsInProgress: true } ||
+            !TryGetCardModel(holder, out var currentModel) ||
+            !ReferenceEquals(currentModel, model))
             return;
 
-        var vanillaShow = model.CanPlay() || model.ShouldGlowRed || model.ShouldGlowGold;
-        var force = rule.VisibleWhenUnplayable && !vanillaShow;
-        if (!vanillaShow && !force)
-            return;
+        try
+        {
+            var cardNode = holder!.CardNode;
+            if (cardNode == null || !GodotObject.IsInstanceValid(cardNode) ||
+                !GodotObject.IsInstanceValid(cardNode.CardHighlight))
+                return;
 
-        var highlight = holder.CardNode!.CardHighlight;
-        if (force)
-            highlight.AnimShow();
+            var vanillaShow = model.CanPlay() || model.ShouldGlowRed || model.ShouldGlowGold;
+            var force = rule.VisibleWhenUnplayable && !vanillaShow;
+            if (!vanillaShow && !force)
+                return;
 
-        highlight.Modulate = rule.ResolveColor(model);
+            var highlight = cardNode.CardHighlight;
+            if (force)
+                highlight.AnimShow();
+
+            highlight.Modulate = rule.ResolveColor(model);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
     }
 
-    internal static void ApplyFlash(NHandCardHolder holder, CardModel model, ModCardHandOutlineRule rule)
+    internal static void ApplyFlash(NHandCardHolder? holder, CardModel model, ModCardHandOutlineRule rule)
     {
-        if (AccessTools.Field(typeof(NHandCardHolder), "_flash")?.GetValue(holder) is not Control flash ||
-            !GodotObject.IsInstanceValid(flash))
+        if (!IsHolderUsable(holder))
             return;
 
-        flash.Modulate = rule.ResolveColor(model);
+        try
+        {
+            if (AccessTools.Field(typeof(NHandCardHolder), "_flash")?.GetValue(holder!) is not Control flash ||
+                !GodotObject.IsInstanceValid(flash))
+                return;
+
+            flash.Modulate = rule.ResolveColor(model);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    internal static bool TryGetUsableTree(NHandCardHolder? holder, out SceneTree tree)
+    {
+        tree = null!;
+
+        if (!IsHolderUsable(holder))
+            return false;
+
+        try
+        {
+            if (holder!.GetTree() is not { } t || !GodotObject.IsInstanceValid(t))
+                return false;
+
+            tree = t;
+            return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryGetCardModel(NHandCardHolder? holder, out CardModel model)
+    {
+        model = null!;
+
+        if (!IsHolderUsable(holder))
+            return false;
+
+        try
+        {
+            if (holder!.CardNode is not { } cardNode ||
+                !GodotObject.IsInstanceValid(cardNode) ||
+                cardNode.Model is not { } m)
+                return false;
+
+            model = m;
+            return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsHolderUsable(NHandCardHolder? holder)
+    {
+        if (holder == null || !GodotObject.IsInstanceValid(holder))
+            return false;
+
+        try
+        {
+            return holder.IsNodeReady() && holder.IsInsideTree();
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
     }
 }

--- a/Hooks/ModCardHandOutlineRegistry.cs
+++ b/Hooks/ModCardHandOutlineRegistry.cs
@@ -20,6 +20,7 @@ public static class ModCardHandOutlineRegistry
     private static readonly ConcurrentDictionary<Type, List<RegisteredRule>> RulesByCardType = new();
     private static readonly Lock ForeignLock = new();
     private static readonly List<ForeignProvider> ForeignProviders = [];
+    private static readonly List<ForeignDynamicProvider> ForeignDynamicProviders = [];
 
     /// <summary>
     ///     Registers a rule for <typeparamref name="TCard" />.
@@ -75,6 +76,23 @@ public static class ModCardHandOutlineRegistry
     }
 
     /// <summary>
+    ///     Merges dynamic outline evaluation from another assembly. The delegate returns current paint resolver and metadata.
+    /// </summary>
+    public static void RegisterForeignDynamic(string modId, string sourceId,
+        Func<CardModel, (Func<Color> ResolveColor, int Priority, bool VisibleWhenUnplayable)?> evaluateBestFromForeign)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        ArgumentNullException.ThrowIfNull(evaluateBestFromForeign);
+
+        var order = Interlocked.Increment(ref _foreignOrder);
+        lock (ForeignLock)
+        {
+            ForeignDynamicProviders.Add(new ForeignDynamicProvider(evaluateBestFromForeign, order));
+        }
+    }
+
+    /// <summary>
     ///     Clears all rules and foreign providers (tests / tooling).
     /// </summary>
     public static void ClearForTests()
@@ -83,6 +101,7 @@ public static class ModCardHandOutlineRegistry
         lock (ForeignLock)
         {
             ForeignProviders.Clear();
+            ForeignDynamicProviders.Clear();
         }
     }
 
@@ -153,6 +172,41 @@ public static class ModCardHandOutlineRegistry
                 foreignBest = new ForeignCandidate(candidate, provider.Order);
         }
 
+        List<ForeignDynamicProvider> dynamicSnapshot;
+        lock (ForeignLock)
+        {
+            dynamicSnapshot = [..ForeignDynamicProviders];
+        }
+
+        foreach (var provider in dynamicSnapshot)
+        {
+            (Func<Color> ResolveColor, int Priority, bool VisibleWhenUnplayable)? foreignPaint;
+            try
+            {
+                foreignPaint = provider.Evaluate(model);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (foreignPaint is not { } paint || paint.ResolveColor == null)
+                continue;
+
+            var candidate = new ModCardHandOutlineRule(
+                ForeignPredicateAlreadySatisfied,
+                paint.ResolveColor(),
+                paint.Priority,
+                paint.VisibleWhenUnplayable)
+            {
+                DynamicColor = _ => paint.ResolveColor(),
+            };
+
+            if (foreignBest is null ||
+                RuleWins(candidate, provider.Order, foreignBest.Value.Rule, foreignBest.Value.Order))
+                foreignBest = new ForeignCandidate(candidate, provider.Order);
+        }
+
         switch (local)
         {
             case null when foreignBest is null:
@@ -204,6 +258,10 @@ public static class ModCardHandOutlineRegistry
 
     private readonly record struct ForeignProvider(
         Func<CardModel, (Color Color, int Priority, bool VisibleWhenUnplayable)?> Evaluate,
+        int Order);
+
+    private readonly record struct ForeignDynamicProvider(
+        Func<CardModel, (Func<Color> ResolveColor, int Priority, bool VisibleWhenUnplayable)?> Evaluate,
         int Order);
 
     private readonly record struct ForeignCandidate(ModCardHandOutlineRule Rule, int Order);

--- a/Hooks/ModCardHandOutlineRegistry.cs
+++ b/Hooks/ModCardHandOutlineRegistry.cs
@@ -31,16 +31,16 @@ public static class ModCardHandOutlineRegistry
     }
 
     /// <summary>
-    ///     Registers a rule for <paramref name="cardType" /> (concrete <see cref="CardModel" /> subtype).
+    ///     Registers a rule for <paramref name="cardType" /> (<see cref="CardModel" /> subtype).
     /// </summary>
     public static void Register(Type cardType, ModCardHandOutlineRule rule)
     {
         ArgumentNullException.ThrowIfNull(cardType);
         ArgumentNullException.ThrowIfNull(rule.When);
 
-        if (cardType.IsAbstract || !typeof(CardModel).IsAssignableFrom(cardType))
+        if (!typeof(CardModel).IsAssignableFrom(cardType))
             throw new ArgumentException(
-                $"Type '{cardType.FullName}' must be a concrete subtype of {typeof(CardModel).FullName}.",
+                $"Type '{cardType.FullName}' must be a subtype of {typeof(CardModel).FullName}.",
                 nameof(cardType));
 
         var seq = Interlocked.Increment(ref _sequence);

--- a/Hooks/ModCardHandOutlineRegistry.cs
+++ b/Hooks/ModCardHandOutlineRegistry.cs
@@ -103,6 +103,22 @@ public static class ModCardHandOutlineRegistry
         return true;
     }
 
+    /// <summary>
+    ///     Applies outline only when the winning rule uses <see cref="ModCardHandOutlineRule.DynamicColor" />.
+    /// </summary>
+    public static bool TryRefreshDynamicOutlineForHolder(NHandCardHolder? holder)
+    {
+        if (holder == null || !holder.IsNodeReady() || holder.CardNode?.Model is not { } model)
+            return false;
+
+        var rule = EvaluateBest(model);
+        if (!rule.HasValue || rule.Value.DynamicColor == null)
+            return false;
+
+        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule.Value);
+        return true;
+    }
+
     internal static ModCardHandOutlineRule? EvaluateBest(CardModel model)
     {
         var local = EvaluateLocalBest(model);

--- a/Hooks/ModCardHandOutlineRegistry.cs
+++ b/Hooks/ModCardHandOutlineRegistry.cs
@@ -1,0 +1,194 @@
+using System.Collections.Concurrent;
+using Godot;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
+
+namespace BaseLib.Hooks;
+
+/// <summary>
+///     Per–card-type custom outline colors for the in-hand <see cref="MegaCrit.Sts2.Core.Nodes.Cards.NCardHighlight" />.
+///     Applied after vanilla <see cref="NHandCardHolder.UpdateCard" /> via Harmony. Foreign providers (e.g. RitsuLib)
+///     merge via <see cref="RegisterForeign" />.
+/// </summary>
+public static class ModCardHandOutlineRegistry
+{
+    private static readonly Func<CardModel, bool> ForeignPredicateAlreadySatisfied = static _ => true;
+
+    private static int _sequence;
+    private static int _foreignOrder;
+
+    private static readonly ConcurrentDictionary<Type, List<RegisteredRule>> RulesByCardType = new();
+    private static readonly Lock ForeignLock = new();
+    private static readonly List<ForeignProvider> ForeignProviders = [];
+
+    /// <summary>
+    ///     Registers a rule for <typeparamref name="TCard" />.
+    /// </summary>
+    public static void Register<TCard>(ModCardHandOutlineRule rule) where TCard : CardModel
+    {
+        Register(typeof(TCard), rule);
+    }
+
+    /// <summary>
+    ///     Registers a rule for <paramref name="cardType" /> (concrete <see cref="CardModel" /> subtype).
+    /// </summary>
+    public static void Register(Type cardType, ModCardHandOutlineRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(cardType);
+        ArgumentNullException.ThrowIfNull(rule.When);
+
+        if (cardType.IsAbstract || !typeof(CardModel).IsAssignableFrom(cardType))
+            throw new ArgumentException(
+                $"Type '{cardType.FullName}' must be a concrete subtype of {typeof(CardModel).FullName}.",
+                nameof(cardType));
+
+        var seq = Interlocked.Increment(ref _sequence);
+        var wrapped = new RegisteredRule(rule, seq);
+
+        RulesByCardType.AddOrUpdate(
+            cardType,
+            _ => [wrapped],
+            (_, existing) =>
+            {
+                var copy = new List<RegisteredRule>(existing) { wrapped };
+                return copy;
+            });
+    }
+
+    /// <summary>
+    ///     Merges outline evaluation from another assembly (e.g. RitsuLib). The delegate must return
+    ///     <see langword="null" /> when no rule applies, otherwise paint fields only — the foreign registry has already
+    ///     evaluated <c>When</c>. Uses <see cref="ValueTuple" /> so the boundary stays a nullable struct (no heap boxing).
+    /// </summary>
+    public static void RegisterForeign(string modId, string sourceId,
+        Func<CardModel, (Color Color, int Priority, bool VisibleWhenUnplayable)?> evaluateBestFromForeign)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(modId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceId);
+        ArgumentNullException.ThrowIfNull(evaluateBestFromForeign);
+
+        var order = Interlocked.Increment(ref _foreignOrder);
+        lock (ForeignLock)
+        {
+            ForeignProviders.Add(new ForeignProvider(evaluateBestFromForeign, order));
+        }
+    }
+
+    /// <summary>
+    ///     Clears all rules and foreign providers (tests / tooling).
+    /// </summary>
+    public static void ClearForTests()
+    {
+        RulesByCardType.Clear();
+        lock (ForeignLock)
+        {
+            ForeignProviders.Clear();
+        }
+    }
+
+    /// <summary>
+    ///     Applies the best matching registered outline for this holder.
+    /// </summary>
+    /// <returns><see langword="true" /> if a rule was applied.</returns>
+    public static bool TryRefreshOutlineForHolder(NHandCardHolder? holder)
+    {
+        if (holder == null || !holder.IsNodeReady() || holder.CardNode?.Model is not { } model)
+            return false;
+
+        var rule = EvaluateBest(model);
+        if (!rule.HasValue)
+            return false;
+
+        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule.Value);
+        return true;
+    }
+
+    internal static ModCardHandOutlineRule? EvaluateBest(CardModel model)
+    {
+        var local = EvaluateLocalBest(model);
+        ForeignCandidate? foreignBest = null;
+
+        List<ForeignProvider> snapshot;
+        lock (ForeignLock)
+        {
+            snapshot = [..ForeignProviders];
+        }
+
+        foreach (var provider in snapshot)
+        {
+            (Color Color, int Priority, bool VisibleWhenUnplayable)? foreignPaint;
+            try
+            {
+                foreignPaint = provider.Evaluate(model);
+            }
+            catch
+            {
+                continue;
+            }
+
+            if (foreignPaint is not { } paint)
+                continue;
+
+            var candidate = new ModCardHandOutlineRule(ForeignPredicateAlreadySatisfied, paint.Color, paint.Priority,
+                paint.VisibleWhenUnplayable);
+
+            if (foreignBest is null ||
+                RuleWins(candidate, provider.Order, foreignBest.Value.Rule, foreignBest.Value.Order))
+                foreignBest = new ForeignCandidate(candidate, provider.Order);
+        }
+
+        switch (local)
+        {
+            case null when foreignBest is null:
+                return null;
+            case null:
+                return foreignBest.Value.Rule;
+        }
+
+        if (foreignBest is null)
+            return local.Value.Rule;
+
+        return RuleWins(foreignBest.Value.Rule, foreignBest.Value.Order, local.Value.Rule, local.Value.Sequence)
+            ? foreignBest.Value.Rule
+            : local.Value.Rule;
+    }
+
+    private static RegisteredRule? EvaluateLocalBest(CardModel model)
+    {
+        RegisteredRule? best = null;
+
+        for (var t = model.GetType();
+             t != null && typeof(CardModel).IsAssignableFrom(t);
+             t = t.BaseType)
+        {
+            if (!RulesByCardType.TryGetValue(t, out var list))
+                continue;
+
+            foreach (var entry in list.Where(entry => entry.Rule.When(model)).Where(entry => best is null
+                         || entry.Rule.Priority > best.Value.Rule.Priority
+                         || (entry.Rule.Priority == best.Value.Rule.Priority &&
+                             entry.Sequence > best.Value.Sequence)))
+                best = entry;
+        }
+
+        return best;
+    }
+
+    private static bool RuleWins(ModCardHandOutlineRule challenger, int challengerOrder,
+        ModCardHandOutlineRule incumbent,
+        int incumbentOrder)
+    {
+        if (challenger.Priority != incumbent.Priority)
+            return challenger.Priority > incumbent.Priority;
+
+        return challengerOrder > incumbentOrder;
+    }
+
+    private readonly record struct RegisteredRule(ModCardHandOutlineRule Rule, int Sequence);
+
+    private readonly record struct ForeignProvider(
+        Func<CardModel, (Color Color, int Priority, bool VisibleWhenUnplayable)?> Evaluate,
+        int Order);
+
+    private readonly record struct ForeignCandidate(ModCardHandOutlineRule Rule, int Order);
+}

--- a/Hooks/ModCardHandOutlineRegistry.cs
+++ b/Hooks/ModCardHandOutlineRegistry.cs
@@ -111,14 +111,10 @@ public static class ModCardHandOutlineRegistry
     /// <returns><see langword="true" /> if a rule was applied.</returns>
     public static bool TryRefreshOutlineForHolder(NHandCardHolder? holder)
     {
-        if (holder == null || !holder.IsNodeReady() || holder.CardNode?.Model is not { } model)
+        if (!ModCardHandOutlinePatchHelper.TryGetRule(holder, out var model, out var rule))
             return false;
 
-        var rule = EvaluateBest(model);
-        if (!rule.HasValue)
-            return false;
-
-        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule.Value);
+        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule);
         return true;
     }
 
@@ -127,14 +123,11 @@ public static class ModCardHandOutlineRegistry
     /// </summary>
     public static bool TryRefreshDynamicOutlineForHolder(NHandCardHolder? holder)
     {
-        if (holder == null || !holder.IsNodeReady() || holder.CardNode?.Model is not { } model)
+        if (!ModCardHandOutlinePatchHelper.TryGetRule(holder, out var model, out var rule) ||
+            rule.DynamicColor == null)
             return false;
 
-        var rule = EvaluateBest(model);
-        if (!rule.HasValue || rule.Value.DynamicColor == null)
-            return false;
-
-        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule.Value);
+        ModCardHandOutlinePatchHelper.ApplyHighlight(holder, model, rule);
         return true;
     }
 

--- a/Hooks/ModCardHandOutlineRule.cs
+++ b/Hooks/ModCardHandOutlineRule.cs
@@ -21,4 +21,33 @@ public readonly record struct ModCardHandOutlineRule(
     Func<CardModel, bool> When,
     Color Color,
     int Priority = 0,
-    bool VisibleWhenUnplayable = false);
+    bool VisibleWhenUnplayable = false)
+{
+    /// <summary>
+    ///     Optional dynamic color resolver. When assigned and <see cref="When" /> passes, this is evaluated on refresh
+    ///     to produce current outline color.
+    /// </summary>
+    public Func<CardModel, Color>? DynamicColor { get; init; }
+
+    /// <summary>
+    ///     Creates a rule with a dynamic color resolver.
+    /// </summary>
+    public static ModCardHandOutlineRule Dynamic(
+        Func<CardModel, bool> when,
+        Func<CardModel, Color> colorWhen,
+        int priority = 0,
+        bool visibleWhenUnplayable = false)
+    {
+        ArgumentNullException.ThrowIfNull(when);
+        ArgumentNullException.ThrowIfNull(colorWhen);
+        return new ModCardHandOutlineRule(when, Colors.White, priority, visibleWhenUnplayable)
+        {
+            DynamicColor = colorWhen,
+        };
+    }
+
+    internal Color ResolveColor(CardModel card)
+    {
+        return DynamicColor?.Invoke(card) ?? Color;
+    }
+}

--- a/Hooks/ModCardHandOutlineRule.cs
+++ b/Hooks/ModCardHandOutlineRule.cs
@@ -1,0 +1,24 @@
+using Godot;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Hooks;
+
+/// <summary>
+///     Custom hand-card outline tint for <see cref="MegaCrit.Sts2.Core.Nodes.Cards.NCardHighlight" /> after vanilla
+///     playable / gold / red. Register with <see cref="ModCardHandOutlineRegistry" />.
+/// </summary>
+/// <param name="When">When this returns true for the card instance, the outline color may apply.</param>
+/// <param name="Color">Godot modulate color (alpha is respected; vanilla highlights use ~0.98).</param>
+/// <param name="Priority">
+///     When several rules match, the highest <paramref name="Priority" /> wins; ties favor the most recently registered
+///     rule.
+/// </param>
+/// <param name="VisibleWhenUnplayable">
+///     If true, the highlight is forced visible with this color even when the card is not playable and vanilla would not
+///     show gold/red (still only while combat is in progress).
+/// </param>
+public readonly record struct ModCardHandOutlineRule(
+    Func<CardModel, bool> When,
+    Color Color,
+    int Priority = 0,
+    bool VisibleWhenUnplayable = false);

--- a/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
+++ b/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
@@ -41,6 +41,9 @@ internal static class NHandCardHolderDynamicOutlineReadyPatch
     [HarmonyPostfix]
     public static void Postfix(NHandCardHolder __instance)
     {
+        if (!GodotObject.IsInstanceValid(__instance) || !__instance.IsInsideTree() || __instance.GetTree() == null)
+            return;
+
         var id = __instance.GetInstanceId();
         if (!TokensByHolderId.TryAdd(id, new CancellationTokenSource()))
             return;
@@ -55,8 +58,15 @@ internal static class NHandCardHolderDynamicOutlineReadyPatch
         {
             while (!token.IsCancellationRequested && GodotObject.IsInstanceValid(holder))
             {
+                if (!holder.IsInsideTree())
+                    break;
+
                 ModCardHandOutlineRegistry.TryRefreshDynamicOutlineForHolder(holder);
-                await holder.ToSignal(holder.GetTree(), SceneTree.SignalName.ProcessFrame);
+                var tree = holder.GetTree();
+                if (tree == null || !GodotObject.IsInstanceValid(tree))
+                    break;
+
+                await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);
             }
         }
         finally

--- a/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
+++ b/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
@@ -1,0 +1,31 @@
+using BaseLib.Hooks;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
+
+namespace BaseLib.Patches.Cards;
+
+[HarmonyPatch(typeof(NHandCardHolder), nameof(NHandCardHolder.UpdateCard))]
+internal static class NHandCardHolderUpdateCardHandOutlinePatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NHandCardHolder __instance)
+    {
+        if (!ModCardHandOutlinePatchHelper.TryGetRule(__instance, out var model, out var rule))
+            return;
+
+        ModCardHandOutlinePatchHelper.ApplyHighlight(__instance, model, rule);
+    }
+}
+
+[HarmonyPatch(typeof(NHandCardHolder), nameof(NHandCardHolder.Flash))]
+internal static class NHandCardHolderFlashHandOutlinePatch
+{
+    [HarmonyPostfix]
+    public static void Postfix(NHandCardHolder __instance)
+    {
+        if (!ModCardHandOutlinePatchHelper.TryGetRule(__instance, out _, out var rule))
+            return;
+
+        ModCardHandOutlinePatchHelper.ApplyFlash(__instance, rule);
+    }
+}

--- a/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
+++ b/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
@@ -1,5 +1,8 @@
+using System.Collections.Concurrent;
 using BaseLib.Hooks;
+using Godot;
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Nodes.Cards.Holders;
 
 namespace BaseLib.Patches.Cards;
@@ -23,9 +26,61 @@ internal static class NHandCardHolderFlashHandOutlinePatch
     [HarmonyPostfix]
     public static void Postfix(NHandCardHolder __instance)
     {
-        if (!ModCardHandOutlinePatchHelper.TryGetRule(__instance, out _, out var rule))
+        if (!ModCardHandOutlinePatchHelper.TryGetRule(__instance, out var model, out var rule))
             return;
 
-        ModCardHandOutlinePatchHelper.ApplyFlash(__instance, rule);
+        ModCardHandOutlinePatchHelper.ApplyFlash(__instance, model, rule);
+    }
+}
+
+[HarmonyPatch(typeof(NHandCardHolder), nameof(NHandCardHolder._Ready))]
+internal static class NHandCardHolderDynamicOutlineReadyPatch
+{
+    private static readonly ConcurrentDictionary<ulong, CancellationTokenSource> TokensByHolderId = new();
+
+    [HarmonyPostfix]
+    public static void Postfix(NHandCardHolder __instance)
+    {
+        var id = __instance.GetInstanceId();
+        if (!TokensByHolderId.TryAdd(id, new CancellationTokenSource()))
+            return;
+
+        var cts = TokensByHolderId[id];
+        TaskHelper.RunSafely(RunDynamicRefreshLoop(__instance, id, cts.Token));
+    }
+
+    private static async Task RunDynamicRefreshLoop(NHandCardHolder holder, ulong id, CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested && GodotObject.IsInstanceValid(holder))
+            {
+                ModCardHandOutlineRegistry.TryRefreshDynamicOutlineForHolder(holder);
+                await holder.ToSignal(holder.GetTree(), SceneTree.SignalName.ProcessFrame);
+            }
+        }
+        finally
+        {
+            StopLoop(id);
+        }
+    }
+
+    internal static void StopLoop(ulong id)
+    {
+        if (!TokensByHolderId.TryRemove(id, out var cts))
+            return;
+
+        cts.Cancel();
+        cts.Dispose();
+    }
+}
+
+[HarmonyPatch(typeof(NHandCardHolder), nameof(NHandCardHolder._ExitTree))]
+internal static class NHandCardHolderDynamicOutlineExitTreePatch
+{
+    [HarmonyPrefix]
+    public static void Prefix(NHandCardHolder __instance)
+    {
+        NHandCardHolderDynamicOutlineReadyPatch.StopLoop(__instance.GetInstanceId());
     }
 }

--- a/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
+++ b/Patches/Cards/NHandCardHolderHandOutlinePatches.cs
@@ -41,7 +41,7 @@ internal static class NHandCardHolderDynamicOutlineReadyPatch
     [HarmonyPostfix]
     public static void Postfix(NHandCardHolder __instance)
     {
-        if (!GodotObject.IsInstanceValid(__instance) || !__instance.IsInsideTree() || __instance.GetTree() == null)
+        if (!ModCardHandOutlinePatchHelper.TryGetUsableTree(__instance, out _))
             return;
 
         var id = __instance.GetInstanceId();
@@ -56,14 +56,10 @@ internal static class NHandCardHolderDynamicOutlineReadyPatch
     {
         try
         {
-            while (!token.IsCancellationRequested && GodotObject.IsInstanceValid(holder))
+            while (!token.IsCancellationRequested)
             {
-                if (!holder.IsInsideTree())
-                    break;
-
                 ModCardHandOutlineRegistry.TryRefreshDynamicOutlineForHolder(holder);
-                var tree = holder.GetTree();
-                if (tree == null || !GodotObject.IsInstanceValid(tree))
+                if (!ModCardHandOutlinePatchHelper.TryGetUsableTree(holder, out var tree))
                     break;
 
                 await tree.ToSignal(tree, SceneTree.SignalName.ProcessFrame);


### PR DESCRIPTION
This pull request introduces a new extensible system for customizing the outline color of hand cards in combat, allowing both local and foreign (cross-mod) rules to control the highlight color and visibility. The system is modular, supports priority-based rule selection, and integrates with the game's update and flash methods via Harmony patches.

**Custom Hand Card Outline System**

* Added a registry and rule system for per-card-type custom hand outline colors, supporting both local and foreign (e.g., other mods) providers. Rules can specify color, priority, and whether to force visibility when unplayable. [[1]](diffhunk://#diff-688c0e46028471e2f97596c894a1d7707ba518e5e7c72699909deea54b8362f1R1-R194) [[2]](diffhunk://#diff-5775518f4bdd1a2e55a6f95f5c6e7bc556b4258e1364e8f50db5165de967fb1fR1-R24)
* Introduced `ModCardHandOutlineRule` as a record struct to encapsulate outline color, activation condition, priority, and visibility behavior.
* Provided helper methods in `ModCardHandOutlinePatchHelper` for evaluating and applying outline rules to card holders, including both highlight and flash effects.

**Integration with Game Logic**

* Patched `NHandCardHolder.UpdateCard` and `NHandCardHolder.Flash` using Harmony to apply the custom outline logic after vanilla behavior, ensuring modded outlines are visible during card updates and flashes.

**Extensibility & Testing**

* The registry supports clearing all rules and foreign providers, facilitating testing and dynamic reconfiguration.

<img width="520" height="434" alt="image" src="https://github.com/user-attachments/assets/21be8602-241a-4b35-89a3-8fd897eae6f1" />
