### PR TITLE
Fixed an issue where other mods not using baselib might get different ids depending on the load order

### DIFF
--- a/Patches/Content/PrefixIdPatch.cs
+++ b/Patches/Content/PrefixIdPatch.cs
@@ -11,30 +11,40 @@ namespace BaseLib.Patches.Content;
 [HarmonyPatch(typeof(ModelDb), nameof(ModelDb.GetEntry))]
 public class PrefixIdPatch
 {
-    private static readonly ConcurrentDictionary<Type, string> IdCache = new();
+    /// <summary>Types where BaseLib rewrites <c>GetEntry</c> (custom id or <see cref="ICustomModel" /> prefix).</summary>
+    private static readonly ConcurrentDictionary<Type, string> TransformCache = new();
+
+    /// <summary>Types already classified as needing no BaseLib transform (skip reflection on later calls).</summary>
+    private static readonly ConcurrentDictionary<Type, byte> PassthroughTypes = new();
 
     [HarmonyPostfix]
-    static string AdjustID(string __result, Type type)
+    static void AdjustID(ref string __result, Type type)
     {
-        if (IdCache.TryGetValue(type, out var cachedId))
+        if (PassthroughTypes.TryGetValue(type, out _))
+            return;
+
+        if (TransformCache.TryGetValue(type, out var cached))
         {
-            return cachedId;
+            __result = cached;
+            return;
         }
-        
+
         var attr = type.GetCustomAttribute<CustomIDAttribute>();
         if (attr != null)
         {
-            IdCache[type] = attr.ID;
-            return attr.ID;
-        }
-        
-        if (type.IsAssignableTo(typeof(ICustomModel)))
-        {
-            IdCache[type] = type.GetPrefix() + __result;
-            return IdCache[type];
+            TransformCache[type] = attr.ID;
+            __result = attr.ID;
+            return;
         }
 
-        IdCache[type] = __result;
-        return __result;
+        if (type.IsAssignableTo(typeof(ICustomModel)))
+        {
+            var prefixed = type.GetPrefix() + __result;
+            TransformCache[type] = prefixed;
+            __result = prefixed;
+            return;
+        }
+
+        PassthroughTypes.TryAdd(type, 0);
     }
 }


### PR DESCRIPTION
In Harmony, patches that use return values to output results are handled separately for sorting and patching from patches that use ref __result.
Since most patches use ref __result for handling.
I believe its working behavior should therefore be unified.

Additionally, I have confirmed that some mods currently receive different entry IDs under different load orders due to the current working behavior.
Causes other non-BaseLib mods to not work properly