### PR TITLE
Modconfig scrolling and controller fixes

### DIFF
--- a/Config/ModConfig.cs
+++ b/Config/ModConfig.cs
@@ -481,7 +481,7 @@ public abstract partial class ModConfig
 
         var dropdownPositioner = new NDropdownPositioner();
         dropdownPositioner.SetCustomMinimumSize(new(324, 64));
-        dropdownPositioner.FocusMode = Control.FocusModeEnum.All;
+        dropdownPositioner.FocusMode = Control.FocusModeEnum.None;
         dropdownPositioner.SizeFlagsHorizontal = Control.SizeFlags.ShrinkEnd;
         dropdownPositioner.SizeFlagsVertical = Control.SizeFlags.Fill;
 

--- a/Config/SimpleModConfig.cs
+++ b/Config/SimpleModConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
 using BaseLib.Config.UI;
+using BaseLib.Extensions;
 using Godot;
 using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
@@ -31,6 +32,7 @@ public class SimpleModConfig : ModConfig
         BaseLibMain.Logger.Info($"Setting up SimpleModConfig {GetType().FullName}");
         GenerateOptionsForAllProperties(optionContainer);
         AddRestoreDefaultsButton(optionContainer);
+        SetupFocusNeighbors(optionContainer);
     }
 
     protected void AddRestoreDefaultsButton(Control optionContainer)
@@ -55,11 +57,6 @@ public class SimpleModConfig : ModConfig
         centerContainer.AddChild(resetButton);
 
         optionContainer.AddChild(centerContainer);
-
-        var selfNodePath = new NodePath(".");
-        resetButton.FocusNeighborBottom = selfNodePath;
-        resetButton.FocusNeighborLeft = selfNodePath;
-        resetButton.FocusNeighborRight = selfNodePath;
     }
 
     public async Task ConfirmRestoreDefaults()
@@ -111,6 +108,7 @@ public class SimpleModConfig : ModConfig
         var control = CreateRawButtonControl(GetLabelText(buttonLabelKey), onPressed);
         var label = CreateRawLabelControl(GetLabelText(rowLabelKey), 28);
         var option = new NConfigOptionRow(ModPrefix, rowLabelKey, label, control);
+        control.ClearFocusNeighbors();
         if (addHoverTip) option.AddHoverTip();
         return option;
     }
@@ -152,6 +150,7 @@ public class SimpleModConfig : ModConfig
         var control = controlCreator.Invoke(property);
         var label = CreateRawLabelControl(GetLabelText(property.Name), 28);
         var option = new NConfigOptionRow(ModPrefix, property.Name, label, control);
+        control.ClearFocusNeighbors();
         if (addHoverTip) option.AddHoverTip();
         return option;
     }
@@ -279,7 +278,6 @@ public class SimpleModConfig : ModConfig
     {
         var sections = new SectionTracker();
         var dividers = new DividerTracker();
-        Control? currentSetting = null;
 
         var filteredMembers = GetFilteredMembers(GetType());
 
@@ -336,11 +334,6 @@ public class SimpleModConfig : ModConfig
                 _configReloadedHandlers.Add(triggerVisibilityUpdate);
             }
 
-            // Set up focus neighbors (mainly for controllers)
-            var previousSetting = currentSetting;
-            currentSetting = newRow.SettingControl;
-            SetupFocusNeighbors(previousSetting, currentSetting);
-
             // Add a divider if appropriate, and assign it to the visibility tracking
             var nextSectionName = nextRowMember?.GetCustomAttribute<ConfigSectionAttribute>()?.Name;
             var nextIsSameSection = nextSectionName == null || nextSectionName == sections.CurrentSectionName;
@@ -361,21 +354,41 @@ public class SimpleModConfig : ModConfig
         dividers.UpdateAll();
     }
 
-    private static void SetupFocusNeighbors(Control? previousSetting, Control currentSetting)
+    /// <summary>
+    /// Connects the first focusable control on each row (each optionContainer child) to each other, for controller
+    /// (and keyboard) navigation.<br/>
+    /// You can run this if you've added or modified controls in some way, to ensure navigation doesn't skip over
+    /// controls, which can happen when Godot tries to guess which control is "next" or "previous" when you navigate.
+    /// </summary>
+    /// <param name="optionContainer">The optionContainer passed to your SetupConfigUI method</param>
+    public static void SetupFocusNeighbors(Control optionContainer)
     {
-        if (previousSetting != null)
-        {
-            currentSetting.FocusNeighborTop = currentSetting.GetPathTo(previousSetting);
-            previousSetting.FocusNeighborBottom = previousSetting.GetPathTo(currentSetting);
-        }
-        else
-        {
-            // Prevent unintended movement to the mod list
-            currentSetting.FocusNeighborTop = selfNodePath;
-        }
+        var focusTargets = optionContainer
+            .GetChildren()
+            .OfType<Control>()
+            .Select(c => c.FindFirstFocusable())
+            .OfType<Control>() // Filter out nulls
+            .ToList();
 
-        currentSetting.FocusNeighborLeft = selfNodePath;
-        currentSetting.FocusNeighborRight = selfNodePath;
+        if (focusTargets.Count == 0) return;
+
+        // Connect each control to the one above/below, and wrap top->bottom and bottom->top
+        for (var i = 0; i < focusTargets.Count; i++)
+        {
+            var current = focusTargets[i];
+
+            // Wrap around
+            var prevTarget = i == 0 ? focusTargets[^1] : focusTargets[i - 1];
+            var nextTarget = i == focusTargets.Count - 1 ? focusTargets[0] : focusTargets[i + 1];
+
+            // Only assign if the mod hasn't explicitly set something up manually, just in case
+            if (current.FocusNeighborTop.IsEmpty) current.FocusNeighborTop = prevTarget.GetPath();
+            if (current.FocusNeighborBottom.IsEmpty) current.FocusNeighborBottom = nextTarget.GetPath();
+
+            // Lock horizontal navigation to the control itself by default
+            if (current.FocusNeighborLeft.IsEmpty) current.FocusNeighborLeft = selfNodePath;
+            if (current.FocusNeighborRight.IsEmpty) current.FocusNeighborRight = selfNodePath;
+        }
     }
 
     private List<MemberInfo> GetFilteredMembers(Type type)

--- a/Config/SimpleModConfig.cs
+++ b/Config/SimpleModConfig.cs
@@ -355,9 +355,10 @@ public class SimpleModConfig : ModConfig
 
         }
 
-        // Ensure the final state is correct for header visibility: the final visibility isn't known until the section
+        // Ensure the final state is correct for visibility: the final visibility isn't known until the section
         // has been fully built.
         sections.UpdateAllHeaderVisibility();
+        dividers.UpdateAll();
     }
 
     private static void SetupFocusNeighbors(Control? previousSetting, Control currentSetting)

--- a/Config/UI/NConfigColorPicker.cs
+++ b/Config/UI/NConfigColorPicker.cs
@@ -1,11 +1,16 @@
 ﻿using System.Reflection;
 using Godot;
+using MegaCrit.Sts2.Core.Assets;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
 
 namespace BaseLib.Config.UI;
 
 public partial class NConfigColorPicker : CenterContainer
 {
     public static readonly Type[] SupportedTypes = [typeof(Color), typeof(string)];
+    private NSelectionReticle _selectionReticle;
     private ColorPickerButton _button;
     private ColorPicker _picker;
     private Popup _popup;
@@ -20,6 +25,7 @@ public partial class NConfigColorPicker : CenterContainer
         SizeFlagsHorizontal = SizeFlags.ShrinkEnd;
         SizeFlagsVertical = SizeFlags.Fill;
         MouseFilter = MouseFilterEnum.Ignore;
+        FocusMode = FocusModeEnum.None;
 
         _button = new ColorPickerButton
         {
@@ -27,6 +33,7 @@ public partial class NConfigColorPicker : CenterContainer
             PivotOffset = new Vector2(22, 22),
             SizeFlagsHorizontal = SizeFlags.ShrinkCenter,
             SizeFlagsVertical = SizeFlags.ShrinkCenter,
+            FocusMode = FocusModeEnum.All,
             MouseFilter = MouseFilterEnum.Stop,
             EditAlpha = true,
             EditIntensity = false
@@ -35,6 +42,15 @@ public partial class NConfigColorPicker : CenterContainer
         AddChild(_button);
         _picker = _button.GetPicker();
         _popup = _button.GetPopup();
+
+        var reticleScene = PreloadManager.Cache.GetScene(SceneHelper.GetScenePath("ui/selection_reticle"));
+        _selectionReticle = reticleScene.Instantiate<NSelectionReticle>();
+        _selectionReticle.Name = "SelectionReticle";
+        _selectionReticle.SetAnchorsAndOffsetsPreset(LayoutPreset.FullRect, margin: -12);
+        _button.AddChild(_selectionReticle);
+
+        _button.Connect(Godot.Control.SignalName.FocusEntered, Callable.From(OnFocus));
+        _button.Connect(Godot.Control.SignalName.FocusExited, Callable.From(OnUnfocus));
 
         var style = new StyleBoxFlat
         {
@@ -118,6 +134,19 @@ public partial class NConfigColorPicker : CenterContainer
         _tween?.Kill();
         _tween = CreateTween().SetParallel();
         _tween.TweenProperty(_button, "scale", Vector2.One, 0.5).SetEase(Tween.EaseType.Out).SetTrans(Tween.TransitionType.Expo);
+    }
+
+    private void OnFocus()
+    {
+        if (NControllerManager.Instance?.IsUsingController != true) return;
+        _selectionReticle.OnSelect();
+        OnHover();
+    }
+
+    private void OnUnfocus()
+    {
+        _selectionReticle.OnDeselect();
+        OnUnhover();
     }
 
     public override void _ExitTree()

--- a/Config/UI/NConfigDropdown.cs
+++ b/Config/UI/NConfigDropdown.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using BaseLib.Utils;
 using Godot;
+using HarmonyLib;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Nodes.CommonUi;
@@ -8,6 +9,13 @@ using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 using MegaCrit.Sts2.Core.Nodes.Screens.Settings;
 
 namespace BaseLib.Config.UI;
+
+[HarmonyPatch(typeof(NDropdownPositioner), nameof(NDropdownPositioner.OnVisibilityChange))]
+public static class NDropdownPositioner_OnVisibilityChange_Patch
+{
+    // This method doesn't do anything useful for us; in fact, it simply ruins our focus neighbor setup.
+    public static bool Prefix(NDropdownPositioner __instance) => __instance._dropdownNode is not NConfigDropdown;
+}
 
 public partial class NConfigDropdown : NSettingsDropdown
 {

--- a/Config/UI/NConfigLineEdit.cs
+++ b/Config/UI/NConfigLineEdit.cs
@@ -1,9 +1,12 @@
 ﻿using System.Reflection;
 using System.Text.RegularExpressions;
 using Godot;
+using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.ControllerInput;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 
 namespace BaseLib.Config.UI;
@@ -13,6 +16,7 @@ public partial class NConfigLineEdit : NMegaLineEdit
     private ModConfig? _config;
     private PropertyInfo? _property;
 
+    private NSelectionReticle _selectionReticle;
     private StyleBoxFlat? _focusInvalid;
     private Regex? _validationRegex;
     private string _lastValidText = "";
@@ -73,8 +77,15 @@ public partial class NConfigLineEdit : NMegaLineEdit
        _focusInvalid.SetCornerRadiusAll(3);
        _focusInvalid.SetExpandMarginAll(2);
 
+       var reticleScene = PreloadManager.Cache.GetScene(SceneHelper.GetScenePath("ui/selection_reticle"));
+       _selectionReticle = reticleScene.Instantiate<NSelectionReticle>();
+       _selectionReticle.Name = "SelectionReticle";
+       _selectionReticle.SetAnchorsAndOffsetsPreset(LayoutPreset.FullRect, margin: -12);
+       AddChild(_selectionReticle);
+
        Connect(Godot.LineEdit.SignalName.TextChanged, Callable.From<string>(OnTextChanged));
        Connect(Godot.LineEdit.SignalName.TextSubmitted, Callable.From<string>(OnTextSubmitted));
+       Connect(Godot.Control.SignalName.FocusEntered, Callable.From(OnFocus));
        Connect(Godot.Control.SignalName.FocusExited, Callable.From(OnUnfocus));
     }
 
@@ -115,9 +126,16 @@ public partial class NConfigLineEdit : NMegaLineEdit
         ReleaseFocus();
     }
 
+    private void OnFocus()
+    {
+        if (NControllerManager.Instance?.IsUsingController == true)
+            _selectionReticle.OnSelect();
+    }
+
     private void OnUnfocus()
     {
         RevertIfInvalid();
+        _selectionReticle.OnDeselect();
     }
 
     private void RevertIfInvalid()

--- a/Config/UI/NModConfigSubmenu.cs
+++ b/Config/UI/NModConfigSubmenu.cs
@@ -28,9 +28,14 @@ public partial class NModConfigSubmenu : NSubmenu
     private ModConfig? _currentConfig;
     private double _saveTimer = -1;
     private bool _modLoadFailed;
+    private bool _lastFocusOnModList = true;
     private const double AutosaveDelay = 5;
+
     private bool _isUsingController;
-    private bool _lastFocusOnRight;
+    private double _navRepeatTimer;
+    private StringName? _heldNavAction;
+    private const float InitialRepeatDelay = 0.4f;
+    private const float RepeatRate = 0.1f;
 
     private const float ModTitleHeight = 90f;
     private const float TopOffset = ModTitleHeight + 30f;
@@ -43,7 +48,7 @@ public partial class NModConfigSubmenu : NSubmenu
     // Read when the screen is shown *and* after a modal (e.g. confirm Restore Defaults). Ensure we return
     // to the same side that was active prior.
     protected override Control? InitialFocusedControl =>
-        _lastFocusOnRight ? FindFirstFocusable(_optionContainer) : GetActiveModButton();
+        _lastFocusOnModList ? GetActiveModButton() : _optionContainer?.FindFirstFocusable();
 
     public NModConfigSubmenu()
     {
@@ -106,6 +111,7 @@ public partial class NModConfigSubmenu : NSubmenu
 
         ConnectSignals();
         GetViewport().Connect(Viewport.SignalName.SizeChanged, Callable.From(RefreshSize));
+        GetViewport().Connect(Viewport.SignalName.GuiFocusChanged, Callable.From<Control>(OnGlobalFocusChanged));
         NControllerManager.Instance?.Connect(NControllerManager.SignalName.MouseDetected,
             Callable.From(InputTypeChanged));
         NControllerManager.Instance?.Connect(NControllerManager.SignalName.ControllerDetected,
@@ -167,32 +173,19 @@ public partial class NModConfigSubmenu : NSubmenu
 
         if (!_isUsingController || _modLoadFailed) return;
 
-        SetBackButtonVisible(false);
         button.SetHotkeyIconVisible(true);
-
-        Callable.From(() => { FindFirstFocusable(_optionContainer)?.TryGrabFocus(); })
+        Callable.From(() => { _optionContainer?.FindFirstFocusable()?.TryGrabFocus(); })
             .CallDeferred();
-        _lastFocusOnRight = true;
     }
 
     private void ModButtonFocused(NModListButton button)
     {
-        _lastFocusOnRight = false;
         SetBackButtonVisible(true);
     }
 
-    private void FocusModList()
+    private void FocusActiveModButton()
     {
-        SetBackButtonVisible(true);
-
-        foreach (var modButton in _modListVbox.GetChildren())
-        {
-            if (modButton is NModListButton listButton)
-                listButton.SetHotkeyIconVisible(false);
-        }
-
-        // Only relevant for controllers, but returns if a controller isn't being used
-        GetActiveModButton()?.TryGrabFocus();
+        Callable.From(() => GetActiveModButton()?.TryGrabFocus()).CallDeferred();
     }
 
     private void SetBackButtonVisible(bool visible)
@@ -221,8 +214,7 @@ public partial class NModConfigSubmenu : NSubmenu
     private void InputTypeChanged()
     {
         _isUsingController = NControllerManager.Instance?.IsUsingController ?? false;
-        _lastFocusOnRight = false;
-        FocusModList();
+        FocusActiveModButton();
     }
 
     public override void _Input(InputEvent @event)
@@ -242,7 +234,7 @@ public partial class NModConfigSubmenu : NSubmenu
             return;
         }
 
-        FocusModList();
+        FocusActiveModButton();
         AcceptEvent();
     }
 
@@ -257,7 +249,6 @@ public partial class NModConfigSubmenu : NSubmenu
         _currentConfig = config;
         config.ConfigChanged += OnConfigChanged;
         SetHighlightedModButton(config);
-        _lastFocusOnRight = false;
 
         // Recreate the container to ensure the previous mod can't change something persistent by mistake
         _optionContainer = CreateOptionContainer();
@@ -318,6 +309,7 @@ public partial class NModConfigSubmenu : NSubmenu
             CustomMinimumSize = new Vector2(0f, 0f),
             AnchorRight = 1f,
             GrowHorizontal = GrowDirection.End,
+            FocusMode = FocusModeEnum.None,
             MouseFilter = MouseFilterEnum.Ignore,
         };
         container.AddChild(new Control { CustomMinimumSize = new Vector2(0, 16) });
@@ -355,6 +347,35 @@ public partial class NModConfigSubmenu : NSubmenu
             fallbackTitle = LocString.GetIfExists("settings_ui", "BASELIB-UNKNOWN_MOD_NAME")!.GetFormattedText();
 
         return fallbackTitle;
+    }
+
+    private void OnGlobalFocusChanged(Control newFocus)
+    {
+        if (!IsVisibleInTree()) return;
+
+        var focusOnModList = _leftScrollArea.IsAncestorOf(newFocus);
+
+        var focusMovedToModList = focusOnModList && !_lastFocusOnModList;
+        var focusMovedToContent = !focusOnModList && _lastFocusOnModList;
+        _lastFocusOnModList = focusOnModList;
+
+        if (focusMovedToModList)
+        {
+            SetBackButtonVisible(true);
+
+            foreach (var modButton in _modListVbox.GetChildren())
+            {
+                if (modButton is NModListButton listButton)
+                    listButton.SetHotkeyIconVisible(false);
+            }
+
+            if (newFocus != GetActiveModButton())
+                FocusActiveModButton();
+        }
+        else if (focusMovedToContent && _isUsingController)
+        {
+            SetBackButtonVisible(false);
+        }
     }
 
     private void RefreshSize()
@@ -436,7 +457,7 @@ public partial class NModConfigSubmenu : NSubmenu
     protected override void OnSubmenuShown()
     {
         base.OnSubmenuShown();
-        _contentPanel.Modulate = new Color();
+        _contentPanel.Modulate = new Color(1f, 1f, 1f, 0f);
 
         _saveTimer = -1;
 
@@ -462,17 +483,22 @@ public partial class NModConfigSubmenu : NSubmenu
             await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
 
             _leftScrollArea.ScrollToFocusedControl(skipAnimation: true);
-
-            _fadeInTween?.Kill();
-            _fadeInTween = CreateTween().SetParallel();
-            _fadeInTween.TweenProperty(_contentPanel, "modulate", Colors.White, 0.5f)
-                .From(new Color(0, 0, 0, 0))
-                .SetEase(Tween.EaseType.Out)
-                .SetTrans(Tween.TransitionType.Cubic);
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            // ignored
+            BaseLibMain.Logger.Error(e.ToString());
+        }
+        finally
+        {
+            if (IsInstanceValid(this) && IsInsideTree())
+            {
+                _fadeInTween?.Kill();
+                _fadeInTween = CreateTween().SetParallel();
+                _fadeInTween.TweenProperty(_contentPanel, "modulate", Colors.White, 0.5f)
+                    .From(new Color(0, 0, 0, 0))
+                    .SetEase(Tween.EaseType.Out)
+                    .SetTrans(Tween.TransitionType.Cubic);
+            }
         }
     }
 
@@ -513,31 +539,46 @@ public partial class NModConfigSubmenu : NSubmenu
         _saveTimer = AutosaveDelay;
     }
 
-    private static Control? FindFirstFocusable(Node? parent)
-    {
-        if (parent == null) return null;
-        foreach (var child in parent.GetChildren())
-        {
-            if (child is Control { FocusMode: FocusModeEnum.All or FocusModeEnum.Click } control)
-                return control;
-
-            var nestedFocus = FindFirstFocusable(child);
-            if (nestedFocus != null)
-                return nestedFocus;
-        }
-
-        return null;
-    }
-
     public override void _Process(double delta)
     {
         base._Process(delta);
+        if (_isUsingController)
+            CreateControllerNavEcho(delta);
+
         if (_saveTimer <= 0) return;
         _saveTimer -= delta;
         if (_saveTimer <= 0)
         {
             SaveCurrentConfig();
         }
+    }
+
+    // Send repeat events of up/down inputs to allow easier movement on controllers
+    private void CreateControllerNavEcho(double delta)
+    {
+        var currentAction =
+            Input.IsActionPressed(MegaInput.down) ? MegaInput.down :
+            Input.IsActionPressed(MegaInput.up) ? MegaInput.up :
+            null;
+
+        if (currentAction != _heldNavAction)
+        {
+            _heldNavAction = currentAction;
+            _navRepeatTimer = InitialRepeatDelay;
+            return;
+        }
+
+        if (currentAction == null) return;
+
+        _navRepeatTimer -= delta;
+        if (_navRepeatTimer > 0) return;
+        _navRepeatTimer = RepeatRate;
+
+        Input.ParseInputEvent(new InputEventAction
+        {
+            Action = currentAction,
+            Pressed = true
+        });
     }
 
     private void SaveCurrentConfig()
@@ -552,6 +593,7 @@ public partial class NModConfigSubmenu : NSubmenu
     public override void _ExitTree()
     {
         GetViewport().Disconnect(Viewport.SignalName.SizeChanged, Callable.From(RefreshSize));
+        GetViewport().Disconnect(Viewport.SignalName.GuiFocusChanged, Callable.From<Control>(OnGlobalFocusChanged));
         NControllerManager.Instance?.Disconnect(NControllerManager.SignalName.MouseDetected,
             Callable.From(InputTypeChanged));
         NControllerManager.Instance?.Disconnect(NControllerManager.SignalName.ControllerDetected,

--- a/Config/UI/NModConfigSubmenu.cs
+++ b/Config/UI/NModConfigSubmenu.cs
@@ -216,8 +216,6 @@ public partial class NModConfigSubmenu : NSubmenu
             if (button is NModListButton listButton)
                 listButton.SetActiveState(listButton.ModName == GetModTitle(config));
         }
-
-        // TODO: scroll to ensure button is visible -- doesn't seem possible at the moment without custom code
     }
 
     private void InputTypeChanged()
@@ -438,6 +436,7 @@ public partial class NModConfigSubmenu : NSubmenu
     protected override void OnSubmenuShown()
     {
         base.OnSubmenuShown();
+        _contentPanel.Modulate = new Color();
 
         _saveTimer = -1;
 
@@ -447,15 +446,34 @@ public partial class NModConfigSubmenu : NSubmenu
         var lastMod = !string.IsNullOrWhiteSpace(lastModId) ? ModConfigRegistry.Get(lastModId) : baseLibConfig;
         LoadModConfig(lastMod ?? baseLibConfig); // lastMod could be null if the mod is no longer loaded
 
-        _fadeInTween?.Kill();
-        _fadeInTween = CreateTween().SetParallel();
-        _fadeInTween.TweenProperty(_contentPanel, "modulate", Colors.White, 0.5f)
-            .From(new Color(0, 0, 0, 0))
-            .SetEase(Tween.EaseType.Out)
-            .SetTrans(Tween.TransitionType.Cubic);
-
         // Ensure back button is visible when switching between controller/mouse, etc.
         Callable.From(InputTypeChanged).CallDeferred();
+
+        WaitForLayoutAndFadeIn();
+    }
+
+    private async void WaitForLayoutAndFadeIn()
+    {
+        // Wait for the layout: one frame is USUALLY but not always enough to avoid jerking.
+        // try/catch due to async void.
+        try
+        {
+            await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+            await ToSignal(GetTree(), SceneTree.SignalName.ProcessFrame);
+
+            _leftScrollArea.ScrollToFocusedControl(skipAnimation: true);
+
+            _fadeInTween?.Kill();
+            _fadeInTween = CreateTween().SetParallel();
+            _fadeInTween.TweenProperty(_contentPanel, "modulate", Colors.White, 0.5f)
+                .From(new Color(0, 0, 0, 0))
+                .SetEase(Tween.EaseType.Out)
+                .SetTrans(Tween.TransitionType.Cubic);
+        }
+        catch (Exception)
+        {
+            // ignored
+        }
     }
 
     protected override void OnSubmenuHidden()

--- a/Config/UI/NNativeScrollableContainer.cs
+++ b/Config/UI/NNativeScrollableContainer.cs
@@ -1,6 +1,8 @@
 ﻿using Godot;
+using HarmonyLib;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Nodes.CommonUi;
 using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
 
 namespace BaseLib.Config.UI;
@@ -10,12 +12,14 @@ public partial class NNativeScrollableContainer : NScrollableContainer
     private Control _clipper;
     private TextureRect _fadeMask;
     private Gradient _maskGradient;
-    private Control? _attachedContent;
 
     private float _topPadding;
     private float _bottomPadding;
 
     public const float ScrollbarGutterWidth = 60f;
+    private const float BottomFade = 70f;
+    private const float TopFade = 24f;
+
     public float AvailableContentWidth => Mathf.Max(0f, Size.X - ScrollbarGutterWidth);
 
     public NNativeScrollableContainer(float topPadding = 0f, float bottomPadding = 0f)
@@ -80,13 +84,11 @@ public partial class NNativeScrollableContainer : NScrollableContainer
 
     public void AttachContent(Control contentPanel)
     {
-        if (_attachedContent != null) _attachedContent.Resized -= OnContentResized;
+        if (_content != null) _content.Resized -= OnContentResized;
 
-        _attachedContent = contentPanel;
         _clipper.AddChild(contentPanel);
         SetContent(contentPanel);
-
-        _attachedContent.Resized += OnContentResized;
+        _content!.Resized += OnContentResized;
         OnContainerResized(); // Initial setup
     }
 
@@ -94,9 +96,6 @@ public partial class NNativeScrollableContainer : NScrollableContainer
     {
         var actualHeight = Size.Y;
         if (actualHeight <= 0) return;
-
-        const float BottomFade = 70f;
-        const float TopFade = 24f;
 
         _maskGradient.Offsets = [
             0f,
@@ -106,19 +105,94 @@ public partial class NNativeScrollableContainer : NScrollableContainer
             FromTop(_topPadding)
         ];
 
+        UpdateScrollLimitBottomOverride();
         OnContentResized();
         return;
 
         float FromTop(float px) => 1f - px / actualHeight;
     }
 
+    public void ScrollToFocusedControl(bool skipAnimation)
+    {
+        if (_content == null || !IsVisibleInTree()) return;
+
+        var focusedControl = GetViewport().GuiGetFocusOwner();
+        if (focusedControl == null || focusedControl is NDropdownItem || !_content.IsAncestorOf(focusedControl)) return;
+
+        var unclampedTarget = _content.GlobalPosition.Y - focusedControl.GlobalPosition.Y + ScrollViewportSize * 0.5f;
+        _targetDragPosY = Mathf.Clamp(unclampedTarget, Mathf.Min(ScrollLimitBottom, 0f), 0f);
+
+        // base._Process handles the Lerp etc.
+        if (!skipAnimation) return;
+
+        // Update position and scrollbar instantly so the _Process Lerp doesn't do anything
+        _content.Position = _content.Position with
+        {
+            Y = _paddingTop + _targetDragPosY
+        };
+
+        if (ScrollLimitBottom >= 0.0f) return;
+        var scrollFraction = Mathf.Clamp(_targetDragPosY / ScrollLimitBottom, 0.0, 1.0);
+        Scrollbar.SetValueWithoutAnimation(scrollFraction * 100.0);
+    }
+
+    // Hack to "override" the non-virtual base method
+    [HarmonyPatch(typeof(NScrollableContainer), nameof(NScrollableContainer.UpdateScrollLimitBottom))]
+    public static class NScrollableContainer_UpdateScrollLimitBottom_Patch
+    {
+        public static bool Prefix(NScrollableContainer __instance)
+        {
+            if (__instance is not NNativeScrollableContainer self) return true;
+
+            self.UpdateScrollLimitBottomOverride();
+            return false;
+        }
+    }
+
+    // Note: this is called on ItemRectChanged, which means it is called *on scroll* as well as on resize.
+    private void UpdateScrollLimitBottomOverride()
+    {
+        if (_content == null) return;
+
+        var wasVisible = Scrollbar.Visible;
+
+        // We don't need nor want sub-pixel accuracy
+        const float Epsilon = 1f;
+
+        // Scroll fix #1: base game decides scrollbar visibility based solely on contentHeight > ViewportSize; this
+        // doesn't take being scrolled down into account, so the scrollbar disappears when scrolled down if the content
+        // "fits", despite some being offscreen.
+        var contentFits = _content.Size.Y + _paddingTop + _paddingBottom - Epsilon <= ScrollViewportSize;
+        var scrollIsAtTop = -_content.Position.Y <= _paddingTop + Epsilon;
+        Scrollbar.Visible = !contentFits || !scrollIsAtTop;
+        Scrollbar.MouseFilter = Scrollbar.Visible ? MouseFilterEnum.Stop : MouseFilterEnum.Ignore;
+
+        // Prevent a jerk when the height changes to require scrolling: base._Process has been suspended and will
+        // try to lerp if the target position doesn't match the current, so make it match
+        if (!wasVisible && Scrollbar.Visible)
+            _targetDragPosY = _content.Position.Y - _paddingTop;
+
+        // Update the fade mask, to not fade the top/bottom if everything fits clearly, or if at the top
+        _fadeMask.ClipChildren = Scrollbar.Visible ? ClipChildrenMode.Only : ClipChildrenMode.Disabled;
+        _fadeMask.SelfModulate = new Color(1f, 1f, 1f, Scrollbar.Visible ? 1f : 0f);
+
+        if (!Scrollbar.Visible) return;
+        var scrollDistanceFromTop = Mathf.Max(0f, _paddingTop - _content.Position.Y);
+        var topAlpha = 1f - Mathf.Clamp(scrollDistanceFromTop / TopFade, 0f, 1f);
+
+        var colors = _maskGradient.Colors;
+        colors[4] = new Color(1f, 1f, 1f, topAlpha);
+        _maskGradient.Colors = colors;
+    }
+
+    // UpdateScrollLimitBottomOverride is called on resize by the base game + Harmony patch above, so this only needs to
+    // handle the logic that method does not perform.
     private void OnContentResized()
     {
-        if (_attachedContent == null) return;
+        if (_content == null) return;
 
-        var needsScroll = _attachedContent.Size.Y > _clipper.Size.Y;
-        Scrollbar.Visible = needsScroll;
-        _fadeMask.ClipChildren = needsScroll ? ClipChildrenMode.Only : ClipChildrenMode.Disabled;
-        _fadeMask.SelfModulate = new Color(1f, 1f, 1f, needsScroll ? 1f : 0f);
+        // Scroll fix #2: base game scrollbar value doesn't update when the content changes, so update it now.
+        // Fixes jumps when you scroll after content size changes.
+        Scrollbar.SetValueNoSignal(Mathf.Clamp((_content.Position.Y - _paddingTop) / ScrollLimitBottom, 0.0f, 1f) * 100.0);
     }
 }

--- a/Extensions/ControlExtensions.cs
+++ b/Extensions/ControlExtensions.cs
@@ -38,4 +38,13 @@ public static class ControlExtensions
             control.AddThemeFontSizeOverride(fontType, fontSize);
         }
     }
+
+    private static readonly NodePath EmptyNodePath = new();
+    public static void ClearFocusNeighbors(this Control control)
+    {
+        control.FocusNeighborTop = EmptyNodePath;
+        control.FocusNeighborBottom = EmptyNodePath;
+        control.FocusNeighborLeft = EmptyNodePath;
+        control.FocusNeighborRight = EmptyNodePath;
+    }
 }

--- a/Extensions/NodeExtensions.cs
+++ b/Extensions/NodeExtensions.cs
@@ -11,4 +11,17 @@ public static class NodeExtensions
         n.AddChild(child);
         child.Owner = n;
     }
+
+    public static Control? FindFirstFocusable(this Node? node)
+    {
+        if (node == null) return null;
+        if (node is Control { FocusMode: Control.FocusModeEnum.All or Control.FocusModeEnum.Click } control)
+            return control;
+
+        return node
+            .GetChildren()
+            .Select(FindFirstFocusable)
+            .OfType<Control>()
+            .FirstOrDefault();
+    }
 }


### PR DESCRIPTION
Plenty of fixes and polish.

* Fix scrollbar visibility on content resize (e.g. due to conditional visibility); scrolling is no longer disabled when the content fits but you're scrolled such that part is off-screen
* Fix scrollbar handle position not updating immediately on content resize
* Scroll down to show+focus the active mod in the list on initial load
* Fix jerk/jump when content suddenly grows to not fit
* Update fade mask to ensure the top is never partially obscured
* Fix divider visibility by refreshing the state when the UI is built; removes some "ghost" dividers that disappeared on any config change

* Rework focus neighbor setup to be more flexible *and* more correct: mods can add controls and ask BaseLib to set them up again, or customize them.

* Allow input repeat on controllers: holding down up/down moves more than one control, after an initial delay.

* Add NSelectionReticle to all controls: specifically, to NConfigColorPicker and NConfigLineEdit, the only ones that were previously missing it.

* Improve focus handling in the mod config screen: if focus somehow moved to the mod list without pressing cancel (B or similar), ensure that the transition is handled correctly, as if B were pressed. Previously, the hotkey icon could remain, and focus would be on the top item of the list, rather than the active.

NConfigColorPicker is not actually usable with a controller, however, as the base Godot color picker doesn't have controller support.