### PR TITLE
Localization var name fix

### DIFF
--- a/BaseLib/localization/eng/powers.json
+++ b/BaseLib/localization/eng/powers.json
@@ -3,7 +3,7 @@
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.description": "Temporarily apply a power to a creature.",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.smartDescription": "Temporarily apply a power to a creature.",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.description": "Increase a [gold]Power[/gold] for some time.",
-  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription": "Gain [blue]{Amount:abs()}[/blue] [gold]{BaseLibTitle}[/gold] until the end of your {UntilEndOfOtherSideTurn:cond:|enemies }turn.{Repeat:cond:>0?\\nLasts for [blue]{Repeat:diff()}[/blue] additional {Repeat:plural:turn|turns}.|}",
+  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription": "Gain [blue]{Amount:abs()}[/blue] [gold]{TemporaryPowerTitle}[/gold] until the end of your {UntilEndOfOtherSideTurn:cond:|enemies }turn.{Repeat:cond:>0?\\nLasts for [blue]{Repeat:diff()}[/blue] additional {Repeat:plural:turn|turns}.|}",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.description": "Decrease a [gold]Power[/gold] for some time.",
-  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription": "Lose [blue]{Amount:abs()}[/blue] [gold]{BaseLibTitle}[/gold] until the end of your {UntilEndOfOtherSideTurn:cond:|enemies }turn.{Repeat:cond:>0?\\nLasts for [blue]{Repeat:diff()}[/blue] additional {Repeat:plural:turn|turns}.|}"
+  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription": "Lose [blue]{Amount:abs()}[/blue] [gold]{TemporaryPowerTitle}[/gold] until the end of your {UntilEndOfOtherSideTurn:cond:|enemies }turn.{Repeat:cond:>0?\\nLasts for [blue]{Repeat:diff()}[/blue] additional {Repeat:plural:turn|turns}.|}"
 }

--- a/BaseLib/localization/rus/powers.json
+++ b/BaseLib/localization/rus/powers.json
@@ -3,7 +3,7 @@
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.description": "Временно накладывает эффект на существо.",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.smartDescription": "Временно накладывает эффект на существо.",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.description": "Временно усиливает эффект [gold]таланта[/gold].",
-  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription": "Дает [blue]{Amount:abs()}[/blue] [gold]{BaseLibTitle}[/gold] до конца хода{UntilEndOfOtherSideTurn:cond:| врага}.{Repeat:cond:>0?\\nДействует еще [blue]{Repeat:diff()}[/blue] доп. {Repeat:plural(ru):ход|хода|ходов}.|}",
+  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription": "Дает [blue]{Amount:abs()}[/blue] [gold]{TemporaryPowerTitle}[/gold] до конца хода{UntilEndOfOtherSideTurn:cond:| врага}.{Repeat:cond:>0?\\nДействует еще [blue]{Repeat:diff()}[/blue] доп. {Repeat:plural(ru):ход|хода|ходов}.|}",
   "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.description": "Временно ослабляет эффект [gold]таланта[/gold].",
-  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription": "Вы теряете [blue]{Amount:abs()}[/blue] [gold]{BaseLibTitle}[/gold] до конца хода {UntilEndOfOtherSideTurn:cond:| врага}.{Repeat:cond:>0?\\nДействует еще [blue]{Repeat:diff()}[/blue] доп. {Repeat:plural(ru):ход|хода|ходов}.|}"
+  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription": "Вы теряете [blue]{Amount:abs()}[/blue] [gold]{TemporaryPowerTitle}[/gold] до конца хода {UntilEndOfOtherSideTurn:cond:| врага}.{Repeat:cond:>0?\\nДействует еще [blue]{Repeat:diff()}[/blue] доп. {Repeat:plural(ru):ход|хода|ходов}.|}"
 }


### PR DESCRIPTION
The locVariable name in TemporaryPowerModelPatch has been changed but the localization files still used the old name.