### PR TITLE
Add events to allow mods to customize other card descriptions.

### DIFF
--- a/Patches/Content/DescriptionOverridePatches.cs
+++ b/Patches/Content/DescriptionOverridePatches.cs
@@ -1,0 +1,67 @@
+﻿using System.Reflection.Emit;
+using BaseLib.Utils.Patching;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Patches.Content;
+
+/// <summary>
+/// Contains patches allowing mods to customize card descriptions globally.
+/// These are intended for mods that add new keyword-like effects that don't necessarily work as actual keywords.
+/// <para/>
+/// Note that just declaring the patches requires Publicize, which doesn't make sense for most mods to require.
+/// Without it, Harmony cannot differentiate between the overloads of <c>GetDescriptionForPile</c>.
+/// </summary>
+[HarmonyPatch]
+public static class DescriptionOverridePatches
+{
+    public delegate void CustomizeDescriptionHandler(CardModel card, Creature? target, ref string description);
+    
+    /// <summary>
+    /// Allows customizing a card's description before it is processed by the game.
+    /// </summary>
+    public static event CustomizeDescriptionHandler? CustomizeDescription;
+
+    /// <summary>
+    /// Allow customizing a card's description after it has been processed by the game.
+    /// </summary>
+    public static event CustomizeDescriptionHandler? CustomizeDescriptionPost;
+    
+    [HarmonyTranspiler]
+    [HarmonyPatch(typeof(CardModel), nameof(CardModel.GetDescriptionForPile),
+        typeof(PileType), typeof(CardModel.DescriptionPreviewType), typeof(Creature))]
+    static List<CodeInstruction> TranspileGetDescriptionForPile(IEnumerable<CodeInstruction> instructionsIn)
+    {
+        return new InstructionPatcher(instructionsIn)
+            .Match(new InstructionMatcher()
+                .ldloc_0()
+                .callvirt(typeof(LocString), nameof(LocString.GetFormattedText))
+                .opcode(OpCodes.Stind_Ref)
+            )
+            .Step(-2)
+            .Insert([
+                CodeInstruction.LoadArgument(0),
+                CodeInstruction.LoadArgument(3),
+            ])
+            // The replace seems necessary, and no, I'm not sure why.
+            .Replace(CodeInstruction.Call(typeof(DescriptionOverridePatches), nameof(InvokeCustomize)));
+    }
+
+    internal static string InvokeCustomize(LocString locString, CardModel card, Creature? target)
+    {
+        var s = locString.GetFormattedText();
+        CustomizeDescription?.Invoke(card, target, ref s);
+        return s;
+    }
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(CardModel), nameof(CardModel.GetDescriptionForPile),
+        typeof(PileType), typeof(CardModel.DescriptionPreviewType), typeof(Creature))]
+    internal static void InvokeCustomizePost(CardModel __instance, Creature? target, ref string __result)
+    {
+        CustomizeDescriptionPost?.Invoke(__instance, target, ref __result);
+    }
+}


### PR DESCRIPTION
The idea is that some mods might have extra effects, things like Sly or Forge, that they want to apply to other cards in hand, draw pile, etc. If those effects are just keywords then fine, but if they require anything more then there's really no easy way for mods to achieve that. Potentially you could do this with an Enchantment, but what if you're aiming for something more like the `Master Planner` ability - apply Sly to all skills after playing them?

As for why this should be in BaseLib, I have two reasons. First, the patches are a bit fragile and multiple people trying to patch would likely cause issues of duplicate labels. Second, even setting up the patch requires using the Publicize library otherwise Harmony gets confused about which method overload you're trying to patch.

Finally, my reasoning for them being `event`s instead of normal hooks: performance and simplicity. While I think it's a feature worth adding to BaseLib to reduce potential mod conflict, I don't think every single card, power, etc. needs the opportunity to edit the descriptions of other cards. You're much more likely to have a single handler that checks if a description needs to be edited.

My only issue is that I'm not sure if putting the events in the class is the best place. Maybe they should be part of `BaseLibSingleton` instead? Or some other more public class?