### PR TITLE
Allow nullable CardPlay parameter in CardBlock methods

### DIFF
--- a/Utils/CommonActions.cs
+++ b/Utils/CommonActions.cs
@@ -137,7 +137,7 @@ public static class CommonActions
     /// Gains Block based on the card's BlockVar<seealso cref="BlockVar"/>.
     /// </summary>
     /// <returns></returns>
-    public static async Task<decimal> CardBlock(CardModel card, CardPlay play)
+    public static async Task<decimal> CardBlock(CardModel card, CardPlay? play)
     {
         return await CardBlock(card, card.DynamicVars.Block, play);
     }
@@ -146,7 +146,7 @@ public static class CommonActions
     /// Gains Block based on the given BlockVar<seealso cref="BlockVar"/>.
     /// </summary>
     /// <returns></returns>
-    public static async Task<decimal> CardBlock(CardModel card, BlockVar blockVar, CardPlay play)
+    public static async Task<decimal> CardBlock(CardModel card, BlockVar blockVar, CardPlay? play)
     {
         return await CreatureCmd.GainBlock(card.Owner.Creature, blockVar, play);
     }
@@ -159,7 +159,7 @@ public static class CommonActions
     /// <param name="play"></param>
     /// <param name="fast"></param>
     /// <returns></returns>
-    public static async Task<decimal> CardBlock(CardModel card, DynamicVar var, CardPlay play, bool fast = false)
+    public static async Task<decimal> CardBlock(CardModel card, DynamicVar var, CardPlay? play, bool fast = false)
     {
         if (var is CalculatedBlockVar calculated)
         {


### PR DESCRIPTION
Since the CardPlay parameter is nullable in CreatureCmd.GainBlock, why should it not also be nullable in CommonActions?  
It can be used now for other card events besides OnPlay when no CardPlay is available.

<img width="837" height="470" alt="grafik" src="https://github.com/user-attachments/assets/a2a0291c-4516-403d-a5ac-3659a1240756" />
