### PR TITLE
Add custom non-character entry buttons to character select

### DIFF
--- a/Abstracts/CustomCharacterSelectEntry.cs
+++ b/Abstracts/CustomCharacterSelectEntry.cs
@@ -1,9 +1,11 @@
 using BaseLib.Patches.Content;
 using Godot;
 using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Localization;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
 using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -51,6 +53,18 @@ public abstract class CustomCharacterSelectEntry : ICustomModel
     public virtual bool VisibleInCharacterSelect => true;
 
     /// <summary>
+    /// Optional character whose vanilla unlock state and lock tooltip semantics should be reused by this entry.
+    /// </summary>
+    public virtual CharacterModel? AvailabilitySourceCharacter => null;
+
+    /// <summary>
+    /// Controls whether this entry is currently unlocked and can be selected.
+    /// Defaults to the unlock state of <seealso cref="AvailabilitySourceCharacter"/> when one is provided.
+    /// </summary>
+    public virtual bool UnlockedInCharacterSelect =>
+        AvailabilitySourceCharacter == null || CustomCharacterSelectEntryAvailability.IsUnlocked(AvailabilitySourceCharacter);
+
+    /// <summary>
     /// Optional default resolved character when the entry is selected.
     /// </summary>
     public virtual CharacterModel? InitialCharacter => null;
@@ -64,6 +78,17 @@ public abstract class CustomCharacterSelectEntry : ICustomModel
     /// Controls whether the vanilla info panel should be shown after this entry resolves to a concrete character.
     /// </summary>
     public virtual bool ShowVanillaInfoPanelWhenResolved => true;
+
+    /// <summary>
+    /// Title shown in the vanilla info panel when this entry is visible but locked and no source character lock panel is used.
+    /// </summary>
+    public virtual string LockedTitle =>
+        new LocString("main_menu_ui", "CHARACTER_SELECT.locked.title").GetFormattedText();
+
+    /// <summary>
+    /// Description shown in the vanilla info panel when this entry is visible but locked and no source character lock panel is used.
+    /// </summary>
+    public virtual string LockedDescription => EntryDescription;
 
     /// <summary>
     /// Override this or <seealso cref="CreateCharacterSelectScene"/> to provide a scene shown in the background container.
@@ -225,5 +250,14 @@ internal static class CustomCharacterSelectEntryRegistry
             var result = a.SortOrder.CompareTo(b.SortOrder);
             return result != 0 ? result : string.CompareOrdinal(a.EntryId, b.EntryId);
         });
+    }
+}
+
+internal static class CustomCharacterSelectEntryAvailability
+{
+    public static bool IsUnlocked(CharacterModel character)
+    {
+        var unlockState = SaveManager.Instance.GenerateUnlockStateFromProgress();
+        return unlockState.Characters.Contains(character);
     }
 }

--- a/Abstracts/CustomCharacterSelectEntry.cs
+++ b/Abstracts/CustomCharacterSelectEntry.cs
@@ -1,0 +1,169 @@
+using BaseLib.Patches.Content;
+using Godot;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+
+namespace BaseLib.Abstracts;
+
+/// <summary>
+/// Registers a custom entry in the character select screen that can resolve into a playable character.
+/// </summary>
+public abstract class CustomCharacterSelectEntry : ICustomModel
+{
+    /// <summary>
+    /// Creates and auto-registers the entry with BaseLib.
+    /// </summary>
+    protected CustomCharacterSelectEntry()
+    {
+        CustomCharacterSelectEntryRegistry.Register(this);
+    }
+
+    /// <summary>
+    /// Stable identifier for this entry. Recommended to include a mod prefix.
+    /// </summary>
+    public virtual string EntryId => StringHelper.Slugify(GetType().FullName ?? GetType().Name);
+
+    /// <summary>
+    /// Icon shown on the custom character select button.
+    /// </summary>
+    public abstract string ButtonIconPath { get; }
+
+    /// <summary>
+    /// Title shown in the info panel while no concrete character is currently resolved.
+    /// </summary>
+    public virtual string EntryTitle => GetType().Name;
+
+    /// <summary>
+    /// Description shown in the info panel while no concrete character is currently resolved.
+    /// </summary>
+    public virtual string EntryDescription => string.Empty;
+
+    /// <summary>
+    /// Sort order among custom entries. Lower values appear first.
+    /// </summary>
+    public virtual int SortOrder => 0;
+
+    /// <summary>
+    /// Override and return false to hide this entry from the character select screen.
+    /// </summary>
+    public virtual bool VisibleInCharacterSelect => true;
+
+    /// <summary>
+    /// Optional default resolved character when the entry is selected.
+    /// </summary>
+    public virtual CharacterModel? InitialCharacter => null;
+
+    /// <summary>
+    /// Override this or <seealso cref="CreateCharacterSelectScene"/> to provide a scene shown in the background container.
+    /// </summary>
+    public virtual string? CharacterSelectScenePath => null;
+
+    /// <summary>
+    /// Create the scene that will be added to the character select background container.
+    /// Override if you want to instantiate or build the node manually.
+    /// </summary>
+    public virtual Control CreateCharacterSelectScene()
+    {
+        if (CharacterSelectScenePath == null)
+        {
+            throw new InvalidOperationException(
+                $"{GetType().FullName} must override either {nameof(CharacterSelectScenePath)} or {nameof(CreateCharacterSelectScene)}.");
+        }
+
+        return ResourceLoader.Load<PackedScene>(CharacterSelectScenePath)
+                   ?.Instantiate<Control>(PackedScene.GenEditState.Disabled)
+               ?? throw new InvalidOperationException(
+                   $"Failed to load character select scene at path '{CharacterSelectScenePath}' for {GetType().FullName}.");
+    }
+
+    /// <summary>
+    /// Called after the entry scene has been instantiated and added to the background container.
+    /// Use the provided context to wire any scene nodes to character selection logic.
+    /// </summary>
+    public virtual void RegisterScene(Control root, CustomCharacterSelectContext context)
+    {
+    }
+}
+
+/// <summary>
+/// Runtime context passed to a custom character select entry scene.
+/// Use it to publish the currently resolved character back to the character select screen.
+/// </summary>
+public sealed class CustomCharacterSelectContext
+{
+    private readonly Action<CharacterModel?> _setCharacter;
+
+    internal CustomCharacterSelectContext(
+        CustomCharacterSelectEntry entry,
+        NCharacterSelectScreen screen,
+        Control sceneRoot,
+        Action<CharacterModel?> setCharacter)
+    {
+        Entry = entry;
+        Screen = screen;
+        SceneRoot = sceneRoot;
+        _setCharacter = setCharacter;
+    }
+
+    /// <summary>
+    /// The entry that created this context.
+    /// </summary>
+    public CustomCharacterSelectEntry Entry { get; }
+
+    /// <summary>
+    /// The owning vanilla character select screen.
+    /// </summary>
+    public NCharacterSelectScreen Screen { get; }
+
+    /// <summary>
+    /// The active lobby backing the current character select screen.
+    /// </summary>
+    public StartRunLobby Lobby => Screen.Lobby;
+
+    /// <summary>
+    /// Root node of the instantiated custom entry scene.
+    /// </summary>
+    public Control SceneRoot { get; }
+
+    /// <summary>
+    /// The character currently resolved by this custom entry, if any.
+    /// </summary>
+    public CharacterModel? SelectedCharacter { get; private set; }
+
+    /// <summary>
+    /// Resolves the current selection to the given playable character.
+    /// Pass <see langword="null"/> to clear the current resolution.
+    /// </summary>
+    public void SetCharacter(CharacterModel? character)
+    {
+        SelectedCharacter = character;
+        _setCharacter(character);
+    }
+
+    /// <summary>
+    /// Clears the currently resolved character and disables embark until a new one is set.
+    /// </summary>
+    public void ClearCharacter()
+    {
+        SetCharacter(null);
+    }
+}
+
+internal static class CustomCharacterSelectEntryRegistry
+{
+    public static readonly List<CustomCharacterSelectEntry> Entries = [];
+
+    public static void Register(CustomCharacterSelectEntry entry)
+    {
+        if (!CustomContentDictionary.RegisterType(entry.GetType())) return;
+
+        Entries.Add(entry);
+        Entries.Sort(static (a, b) =>
+        {
+            var result = a.SortOrder.CompareTo(b.SortOrder);
+            return result != 0 ? result : string.CompareOrdinal(a.EntryId, b.EntryId);
+        });
+    }
+}

--- a/Abstracts/CustomCharacterSelectEntry.cs
+++ b/Abstracts/CustomCharacterSelectEntry.cs
@@ -56,9 +56,24 @@ public abstract class CustomCharacterSelectEntry : ICustomModel
     public virtual CharacterModel? InitialCharacter => null;
 
     /// <summary>
+    /// Controls whether the vanilla info panel should be shown while this entry is active and no concrete character is resolved.
+    /// </summary>
+    public virtual bool ShowVanillaInfoPanelWhenUnresolved => true;
+
+    /// <summary>
+    /// Controls whether the vanilla info panel should be shown after this entry resolves to a concrete character.
+    /// </summary>
+    public virtual bool ShowVanillaInfoPanelWhenResolved => true;
+
+    /// <summary>
     /// Override this or <seealso cref="CreateCharacterSelectScene"/> to provide a scene shown in the background container.
     /// </summary>
     public virtual string? CharacterSelectScenePath => null;
+
+    /// <summary>
+    /// Override this or <seealso cref="CreateCharacterSelectForegroundScene"/> to provide a scene shown above the vanilla character select UI.
+    /// </summary>
+    public virtual string? CharacterSelectForegroundScenePath => null;
 
     /// <summary>
     /// Create the scene that will be added to the character select background container.
@@ -79,10 +94,35 @@ public abstract class CustomCharacterSelectEntry : ICustomModel
     }
 
     /// <summary>
+    /// Create the optional scene that will be added above the vanilla character select UI.
+    /// Override if you want to instantiate or build the node manually.
+    /// Return <see langword="null"/> to omit the foreground layer.
+    /// </summary>
+    public virtual Control? CreateCharacterSelectForegroundScene()
+    {
+        if (CharacterSelectForegroundScenePath == null)
+        {
+            return null;
+        }
+
+        return ResourceLoader.Load<PackedScene>(CharacterSelectForegroundScenePath)
+                   ?.Instantiate<Control>(PackedScene.GenEditState.Disabled)
+               ?? throw new InvalidOperationException(
+                   $"Failed to load character select foreground scene at path '{CharacterSelectForegroundScenePath}' for {GetType().FullName}.");
+    }
+
+    /// <summary>
     /// Called after the entry scene has been instantiated and added to the background container.
     /// Use the provided context to wire any scene nodes to character selection logic.
     /// </summary>
     public virtual void RegisterScene(Control root, CustomCharacterSelectContext context)
+    {
+    }
+
+    /// <summary>
+    /// Called after the optional foreground scene has been instantiated and added above the vanilla character select UI.
+    /// </summary>
+    public virtual void RegisterForegroundScene(Control root, CustomCharacterSelectContext context)
     {
     }
 }
@@ -99,11 +139,13 @@ public sealed class CustomCharacterSelectContext
         CustomCharacterSelectEntry entry,
         NCharacterSelectScreen screen,
         Control sceneRoot,
+        Control? foregroundSceneRoot,
         Action<CharacterModel?> setCharacter)
     {
         Entry = entry;
         Screen = screen;
         SceneRoot = sceneRoot;
+        ForegroundSceneRoot = foregroundSceneRoot;
         _setCharacter = setCharacter;
     }
 
@@ -128,9 +170,19 @@ public sealed class CustomCharacterSelectContext
     public Control SceneRoot { get; }
 
     /// <summary>
+    /// Root node of the instantiated foreground scene, if this entry created one.
+    /// </summary>
+    public Control? ForegroundSceneRoot { get; }
+
+    /// <summary>
     /// The character currently resolved by this custom entry, if any.
     /// </summary>
     public CharacterModel? SelectedCharacter { get; private set; }
+
+    /// <summary>
+    /// Current visibility of the vanilla character info panel.
+    /// </summary>
+    public bool VanillaInfoPanelVisible => Screen._infoPanel.Visible;
 
     /// <summary>
     /// Resolves the current selection to the given playable character.
@@ -148,6 +200,14 @@ public sealed class CustomCharacterSelectContext
     public void ClearCharacter()
     {
         SetCharacter(null);
+    }
+
+    /// <summary>
+    /// Shows or hides the vanilla character info panel.
+    /// </summary>
+    public void SetVanillaInfoPanelVisible(bool visible)
+    {
+        Screen._infoPanel.Visible = visible;
     }
 }
 

--- a/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
+++ b/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
@@ -44,10 +44,7 @@ internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButton
         Button.SetMeta("BaseLibCustomCharacterSelectEntry", entry.EntryId);
 
         DelegateField?.SetValue(Button, this);
-        CharacterField?.SetValue(Button, TemplateCharacter);
-        LockedField?.SetValue(Button, false);
-
-        ApplyVisuals();
+        UpdateInteractionState();
     }
 
     /// <summary>
@@ -64,12 +61,22 @@ internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButton
     public StartRunLobby Lobby => _screen.Lobby;
 
     /// <summary>
+    /// Whether this entry is currently locked.
+    /// </summary>
+    public bool IsLocked => Button.IsLocked;
+
+    /// <summary>
+    /// The character whose vanilla lock semantics are reused by this entry, if any.
+    /// </summary>
+    public CharacterModel? LockSourceCharacter => Entry.AvailabilitySourceCharacter;
+
+    /// <summary>
     /// Enables the underlying button.
     /// </summary>
     public void Enable()
     {
         Button.Enable();
-        ApplyVisuals();
+        UpdateInteractionState();
     }
 
     /// <summary>
@@ -122,8 +129,15 @@ internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButton
         var lockIcon = Button.GetNodeOrNull<TextureRect>("%Lock");
         if (lockIcon != null)
         {
-            lockIcon.Visible = false;
+            lockIcon.Visible = IsLocked;
         }
+    }
+
+    private void UpdateInteractionState()
+    {
+        CharacterField?.SetValue(Button, LockSourceCharacter ?? TemplateCharacter);
+        LockedField?.SetValue(Button, !Entry.UnlockedInCharacterSelect);
+        ApplyVisuals();
     }
 
     private sealed class PlaceholderCharacter : CustomCharacterModel

--- a/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
+++ b/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
@@ -1,0 +1,265 @@
+using BaseLib.Abstracts;
+using BaseLib.Utils;
+using Godot;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
+
+namespace BaseLib.BaseLibScenes;
+
+/// <summary>
+/// Internal UI node for rendering a custom character select entry button.
+/// </summary>
+internal partial class NCustomCharacterSelectEntryButton : NButton
+{
+    private const string OutlineTexturePath = "res://images/packed/character_select/char_select_outline.png";
+    private const string ButtonMaskTexturePath = "res://images/packed/character_select/char_select_button_mask.png";
+    private const string AdditiveMaterialPath = "res://themes/canvas_item_material_additive_shared.tres";
+
+    private static readonly StringName S = new("s");
+    private static readonly StringName V = new("v");
+    private static readonly Vector2 HoverScale = Vector2.One * 1.1f;
+
+    private TextureRect? _icon;
+    private Control? _outline;
+    private ShaderMaterial? _hsv;
+    private Tween? _hoverTween;
+    private Action<NCustomCharacterSelectEntryButton>? _onSelected;
+    private bool _isSelected;
+
+    /// <summary>
+    /// Entry currently bound to this button.
+    /// </summary>
+    public CustomCharacterSelectEntry? Entry { get; private set; }
+
+    public NCustomCharacterSelectEntryButton()
+    {
+        Name = nameof(NCustomCharacterSelectEntryButton);
+        CustomMinimumSize = new Vector2(100, 148);
+        LayoutMode = 3;
+        PivotOffset = new Vector2(50, 74);
+        FocusMode = FocusModeEnum.All;
+
+        var maskTexture = GD.Load<Texture2D>(ButtonMaskTexturePath)
+                          ?? throw new InvalidOperationException($"Failed to load {ButtonMaskTexturePath}.");
+        var outlineTexture = GD.Load<Texture2D>(OutlineTexturePath)
+                             ?? throw new InvalidOperationException($"Failed to load {OutlineTexturePath}.");
+        var additiveMaterial = GD.Load<Material>(AdditiveMaterialPath)
+                               ?? throw new InvalidOperationException($"Failed to load {AdditiveMaterialPath}.");
+
+        var margin = new MarginContainer
+        {
+            Name = "MarginContainer",
+            LayoutMode = 1,
+            MouseFilter = MouseFilterEnum.Ignore
+        };
+        margin.SetAnchorsPreset(LayoutPreset.FullRect);
+        margin.AddThemeConstantOverride("margin_left", 6);
+        margin.AddThemeConstantOverride("margin_top", 9);
+        margin.AddThemeConstantOverride("margin_right", 6);
+        margin.AddThemeConstantOverride("margin_bottom", 9);
+        AddChild(margin);
+
+        var control = new Control
+        {
+            Name = "Control",
+            LayoutMode = 2
+        };
+        margin.AddChild(control);
+
+        var shadow = new TextureRect
+        {
+            Name = "Shadow",
+            Modulate = new Color(0f, 0f, 0f, 0.25f),
+            ShowBehindParent = true,
+            LayoutMode = 0,
+            OffsetLeft = 8f,
+            OffsetTop = 10f,
+            OffsetRight = 96f,
+            OffsetBottom = 140f,
+            GrowHorizontal = GrowDirection.Both,
+            GrowVertical = GrowDirection.Both,
+            PivotOffset = new Vector2(44, 65),
+            MouseFilter = MouseFilterEnum.Ignore,
+            Texture = maskTexture,
+            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize
+        };
+        control.AddChild(shadow);
+
+        _outline = new TextureRect
+        {
+            Name = "Outline",
+            UniqueNameInOwner = true,
+            Visible = false,
+            SelfModulate = new Color(0.94f, 0.706f, 0.16f, 0.85f),
+            ShowBehindParent = true,
+            Material = additiveMaterial,
+            LayoutMode = 0,
+            AnchorRight = 1f,
+            AnchorBottom = 1f,
+            GrowHorizontal = GrowDirection.Both,
+            GrowVertical = GrowDirection.Both,
+            Scale = new Vector2(1.16f, 1.06f),
+            PivotOffset = new Vector2(44, 65),
+            MouseFilter = MouseFilterEnum.Ignore,
+            Texture = outlineTexture,
+            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize
+        };
+        control.AddChild(_outline);
+
+        var mask = new TextureRect
+        {
+            Name = "Mask",
+            ClipChildren = ClipChildrenMode.Only,
+            LayoutMode = 2,
+            Texture = maskTexture,
+            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+            StretchMode = TextureRect.StretchModeEnum.Scale
+        };
+        margin.AddChild(mask);
+
+        _icon = new TextureRect
+        {
+            Name = "Icon",
+            UniqueNameInOwner = true,
+            Material = ShaderUtils.GenerateHsv(1f, 0.2f, 0.8f),
+            LayoutMode = 0,
+            OffsetTop = 3f,
+            OffsetRight = 88f,
+            OffsetBottom = 133f,
+            GrowHorizontal = GrowDirection.Both,
+            GrowVertical = GrowDirection.Both,
+            Scale = new Vector2(1.01f, 1.01f),
+            PivotOffset = new Vector2(44, 65),
+            MouseFilter = MouseFilterEnum.Ignore,
+            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
+            StretchMode = TextureRect.StretchModeEnum.Scale
+        };
+        mask.AddChild(_icon);
+    }
+
+    public override void _Ready()
+    {
+        ConnectSignals();
+        _hsv = (ShaderMaterial)_icon!.Material;
+        _hsv.SetShaderParameter(S, 0.2f);
+        _hsv.SetShaderParameter(V, 0.8f);
+        Connect(Control.SignalName.FocusEntered, Callable.From(Select));
+        if (Entry != null)
+        {
+            _icon.Texture = ResourceLoader.Load<Texture2D>(Entry.ButtonIconPath);
+        }
+        RefreshVisualState(immediate: true);
+    }
+
+    /// <summary>
+    /// Binds the button to an entry and selection callback.
+    /// </summary>
+    public void Initialize(CustomCharacterSelectEntry entry, Action<NCustomCharacterSelectEntryButton> onSelected)
+    {
+        Entry = entry;
+        _onSelected = onSelected;
+
+        if (_icon != null)
+        {
+            _icon.Texture = ResourceLoader.Load<Texture2D>(entry.ButtonIconPath);
+        }
+    }
+
+    /// <summary>
+    /// Marks the button selected and notifies the owning screen.
+    /// </summary>
+    public void Select()
+    {
+        if (_isSelected) return;
+
+        _hoverTween?.Kill();
+        _isSelected = true;
+        _onSelected?.Invoke(this);
+        RefreshVisualState(immediate: false);
+    }
+
+    /// <summary>
+    /// Clears the selected visual state.
+    /// </summary>
+    public void Deselect()
+    {
+        if (!_isSelected) return;
+
+        _isSelected = false;
+        RefreshVisualState(immediate: false);
+    }
+
+    /// <summary>
+    /// Attempts to return keyboard/controller focus to this button.
+    /// </summary>
+    public void TryGrabFocus()
+    {
+        if (Visible && IsInsideTree())
+        {
+            GrabFocus();
+        }
+    }
+
+    protected override void OnFocus()
+    {
+        if (_isSelected) return;
+
+        _hoverTween?.Kill();
+        Scale = HoverScale;
+        _hsv?.SetShaderParameter(S, 1f);
+        _hsv?.SetShaderParameter(V, 1.1f);
+        SfxCmd.Play("event:/sfx/ui/clicks/ui_hover");
+    }
+
+    protected override void OnPress()
+    {
+    }
+
+    protected override void OnUnfocus()
+    {
+        if (_isSelected) return;
+
+        RefreshVisualState(immediate: false);
+    }
+
+    private void RefreshVisualState(bool immediate)
+    {
+        if (_outline == null || _hsv == null) return;
+
+        _outline.Visible = _isSelected;
+
+        var targetScale = _isSelected ? HoverScale : Vector2.One;
+        var targetS = _isSelected ? 1f : 0.2f;
+        var targetV = _isSelected ? 1.1f : 0.8f;
+
+        if (immediate)
+        {
+            Scale = targetScale;
+            _hsv.SetShaderParameter(S, targetS);
+            _hsv.SetShaderParameter(V, targetV);
+            return;
+        }
+
+        _hoverTween?.Kill();
+        _hoverTween = CreateTween().SetParallel();
+        _hoverTween.TweenProperty(this, "scale", targetScale, 0.5f)
+            .SetEase(Tween.EaseType.Out)
+            .SetTrans(Tween.TransitionType.Expo);
+        _hoverTween.TweenMethod(Callable.From<float>(UpdateShaderS), _hsv.GetShaderParameter(S), targetS, 0.5f)
+            .SetEase(Tween.EaseType.Out)
+            .SetTrans(Tween.TransitionType.Expo);
+        _hoverTween.TweenMethod(Callable.From<float>(UpdateShaderV), _hsv.GetShaderParameter(V), targetV, 0.5f)
+            .SetEase(Tween.EaseType.Out)
+            .SetTrans(Tween.TransitionType.Expo);
+    }
+
+    private void UpdateShaderS(float value)
+    {
+        _hsv?.SetShaderParameter(S, value);
+    }
+
+    private void UpdateShaderV(float value)
+    {
+        _hsv?.SetShaderParameter(V, value);
+    }
+}

--- a/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
+++ b/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
@@ -1,181 +1,83 @@
+using System.Reflection;
 using BaseLib.Abstracts;
-using BaseLib.Utils;
 using Godot;
-using MegaCrit.Sts2.Core.Commands;
-using MegaCrit.Sts2.Core.Nodes.GodotExtensions;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Characters;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Characters;
+using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
 
 namespace BaseLib.BaseLibScenes;
 
 /// <summary>
-/// Internal UI node for rendering a custom character select entry button.
+/// Internal adapter that reuses the vanilla character select button scene for a custom entry.
 /// </summary>
-internal partial class NCustomCharacterSelectEntryButton : NButton
+internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButtonDelegate
 {
-    private const string OutlineTexturePath = "res://images/packed/character_select/char_select_outline.png";
-    private const string ButtonMaskTexturePath = "res://images/packed/character_select/char_select_button_mask.png";
-    private const string AdditiveMaterialPath = "res://themes/canvas_item_material_additive_shared.tres";
+    private const string ButtonScenePath = "res://scenes/screens/char_select/char_select_button.tscn";
 
-    private static readonly StringName S = new("s");
-    private static readonly StringName V = new("v");
-    private static readonly Vector2 HoverScale = Vector2.One * 1.1f;
+    private static readonly FieldInfo? DelegateField = AccessTools.Field(typeof(NCharacterSelectButton), "_delegate");
+    private static readonly FieldInfo? CharacterField = AccessTools.Field(typeof(NCharacterSelectButton), "_character");
+    private static readonly FieldInfo? LockedField = AccessTools.Field(typeof(NCharacterSelectButton), "_isLocked");
+    private static readonly PlaceholderCharacter TemplateCharacter = new();
 
-    private TextureRect? _icon;
-    private Control? _outline;
-    private ShaderMaterial? _hsv;
-    private Tween? _hoverTween;
-    private Action<NCustomCharacterSelectEntryButton>? _onSelected;
-    private bool _isSelected;
+    private readonly NCharacterSelectScreen _screen;
+    private readonly Action<NCustomCharacterSelectEntryButton> _onSelected;
 
     /// <summary>
-    /// Entry currently bound to this button.
+    /// Creates a custom entry button that uses the vanilla character select button scene.
     /// </summary>
-    public CustomCharacterSelectEntry? Entry { get; private set; }
-
-    public NCustomCharacterSelectEntryButton()
-    {
-        Name = nameof(NCustomCharacterSelectEntryButton);
-        CustomMinimumSize = new Vector2(100, 148);
-        LayoutMode = 3;
-        PivotOffset = new Vector2(50, 74);
-        FocusMode = FocusModeEnum.All;
-
-        var maskTexture = GD.Load<Texture2D>(ButtonMaskTexturePath)
-                          ?? throw new InvalidOperationException($"Failed to load {ButtonMaskTexturePath}.");
-        var outlineTexture = GD.Load<Texture2D>(OutlineTexturePath)
-                             ?? throw new InvalidOperationException($"Failed to load {OutlineTexturePath}.");
-        var additiveMaterial = GD.Load<Material>(AdditiveMaterialPath)
-                               ?? throw new InvalidOperationException($"Failed to load {AdditiveMaterialPath}.");
-
-        var margin = new MarginContainer
-        {
-            Name = "MarginContainer",
-            LayoutMode = 1,
-            MouseFilter = MouseFilterEnum.Ignore
-        };
-        margin.SetAnchorsPreset(LayoutPreset.FullRect);
-        margin.AddThemeConstantOverride("margin_left", 6);
-        margin.AddThemeConstantOverride("margin_top", 9);
-        margin.AddThemeConstantOverride("margin_right", 6);
-        margin.AddThemeConstantOverride("margin_bottom", 9);
-        AddChild(margin);
-
-        var control = new Control
-        {
-            Name = "Control",
-            LayoutMode = 2
-        };
-        margin.AddChild(control);
-
-        var shadow = new TextureRect
-        {
-            Name = "Shadow",
-            Modulate = new Color(0f, 0f, 0f, 0.25f),
-            ShowBehindParent = true,
-            LayoutMode = 0,
-            OffsetLeft = 8f,
-            OffsetTop = 10f,
-            OffsetRight = 96f,
-            OffsetBottom = 140f,
-            GrowHorizontal = GrowDirection.Both,
-            GrowVertical = GrowDirection.Both,
-            PivotOffset = new Vector2(44, 65),
-            MouseFilter = MouseFilterEnum.Ignore,
-            Texture = maskTexture,
-            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize
-        };
-        control.AddChild(shadow);
-
-        _outline = new TextureRect
-        {
-            Name = "Outline",
-            UniqueNameInOwner = true,
-            Visible = false,
-            SelfModulate = new Color(0.94f, 0.706f, 0.16f, 0.85f),
-            ShowBehindParent = true,
-            Material = additiveMaterial,
-            LayoutMode = 0,
-            AnchorRight = 1f,
-            AnchorBottom = 1f,
-            GrowHorizontal = GrowDirection.Both,
-            GrowVertical = GrowDirection.Both,
-            Scale = new Vector2(1.16f, 1.06f),
-            PivotOffset = new Vector2(44, 65),
-            MouseFilter = MouseFilterEnum.Ignore,
-            Texture = outlineTexture,
-            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize
-        };
-        control.AddChild(_outline);
-
-        var mask = new TextureRect
-        {
-            Name = "Mask",
-            ClipChildren = ClipChildrenMode.Only,
-            LayoutMode = 2,
-            Texture = maskTexture,
-            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
-            StretchMode = TextureRect.StretchModeEnum.Scale
-        };
-        margin.AddChild(mask);
-
-        _icon = new TextureRect
-        {
-            Name = "Icon",
-            UniqueNameInOwner = true,
-            Material = ShaderUtils.GenerateHsv(1f, 0.2f, 0.8f),
-            LayoutMode = 0,
-            OffsetTop = 3f,
-            OffsetRight = 88f,
-            OffsetBottom = 133f,
-            GrowHorizontal = GrowDirection.Both,
-            GrowVertical = GrowDirection.Both,
-            Scale = new Vector2(1.01f, 1.01f),
-            PivotOffset = new Vector2(44, 65),
-            MouseFilter = MouseFilterEnum.Ignore,
-            ExpandMode = TextureRect.ExpandModeEnum.IgnoreSize,
-            StretchMode = TextureRect.StretchModeEnum.Scale
-        };
-        mask.AddChild(_icon);
-    }
-
-    public override void _Ready()
-    {
-        ConnectSignals();
-        _hsv = (ShaderMaterial)_icon!.Material;
-        _hsv.SetShaderParameter(S, 0.2f);
-        _hsv.SetShaderParameter(V, 0.8f);
-        Connect(Control.SignalName.FocusEntered, Callable.From(Select));
-        if (Entry != null)
-        {
-            _icon.Texture = ResourceLoader.Load<Texture2D>(Entry.ButtonIconPath);
-        }
-        RefreshVisualState(immediate: true);
-    }
-
-    /// <summary>
-    /// Binds the button to an entry and selection callback.
-    /// </summary>
-    public void Initialize(CustomCharacterSelectEntry entry, Action<NCustomCharacterSelectEntryButton> onSelected)
+    public NCustomCharacterSelectEntryButton(
+        CustomCharacterSelectEntry entry,
+        NCharacterSelectScreen screen,
+        Action<NCustomCharacterSelectEntryButton> onSelected)
     {
         Entry = entry;
+        _screen = screen;
         _onSelected = onSelected;
 
-        if (_icon != null)
-        {
-            _icon.Texture = ResourceLoader.Load<Texture2D>(entry.ButtonIconPath);
-        }
+        var scene = ResourceLoader.Load<PackedScene>(ButtonScenePath)
+                    ?? throw new InvalidOperationException($"Failed to load {ButtonScenePath}.");
+        Button = scene.Instantiate<NCharacterSelectButton>(PackedScene.GenEditState.Disabled);
+        Button.Name = $"{entry.EntryId}_entry_button";
+        Button.SetMeta("BaseLibCustomCharacterSelectEntry", entry.EntryId);
+
+        DelegateField?.SetValue(Button, this);
+        CharacterField?.SetValue(Button, TemplateCharacter);
+        LockedField?.SetValue(Button, false);
+
+        ApplyVisuals();
     }
 
     /// <summary>
-    /// Marks the button selected and notifies the owning screen.
+    /// The entry represented by this button.
     /// </summary>
-    public void Select()
-    {
-        if (_isSelected) return;
+    public CustomCharacterSelectEntry Entry { get; }
 
-        _hoverTween?.Kill();
-        _isSelected = true;
-        _onSelected?.Invoke(this);
-        RefreshVisualState(immediate: false);
+    /// <summary>
+    /// The instantiated vanilla button node.
+    /// </summary>
+    public NCharacterSelectButton Button { get; }
+
+    /// <inheritdoc />
+    public StartRunLobby Lobby => _screen.Lobby;
+
+    /// <summary>
+    /// Enables the underlying button.
+    /// </summary>
+    public void Enable()
+    {
+        Button.Enable();
+        ApplyVisuals();
+    }
+
+    /// <summary>
+    /// Disables the underlying button.
+    /// </summary>
+    public void Disable()
+    {
+        Button.Disable();
     }
 
     /// <summary>
@@ -183,83 +85,74 @@ internal partial class NCustomCharacterSelectEntryButton : NButton
     /// </summary>
     public void Deselect()
     {
-        if (!_isSelected) return;
-
-        _isSelected = false;
-        RefreshVisualState(immediate: false);
+        Button.Deselect();
     }
 
     /// <summary>
-    /// Attempts to return keyboard/controller focus to this button.
+    /// Attempts to return focus to the underlying button.
     /// </summary>
     public void TryGrabFocus()
     {
-        if (Visible && IsInsideTree())
+        if (Button.Visible && Button.IsInsideTree())
         {
-            GrabFocus();
+            Button.GrabFocus();
         }
     }
 
-    protected override void OnFocus()
+    /// <inheritdoc />
+    public void SelectCharacter(NCharacterSelectButton charSelectButton, CharacterModel characterModel)
     {
-        if (_isSelected) return;
-
-        _hoverTween?.Kill();
-        Scale = HoverScale;
-        _hsv?.SetShaderParameter(S, 1f);
-        _hsv?.SetShaderParameter(V, 1.1f);
-        SfxCmd.Play("event:/sfx/ui/clicks/ui_hover");
+        _onSelected(this);
     }
 
-    protected override void OnPress()
+    private void ApplyVisuals()
     {
-    }
-
-    protected override void OnUnfocus()
-    {
-        if (_isSelected) return;
-
-        RefreshVisualState(immediate: false);
-    }
-
-    private void RefreshVisualState(bool immediate)
-    {
-        if (_outline == null || _hsv == null) return;
-
-        _outline.Visible = _isSelected;
-
-        var targetScale = _isSelected ? HoverScale : Vector2.One;
-        var targetS = _isSelected ? 1f : 0.2f;
-        var targetV = _isSelected ? 1.1f : 0.8f;
-
-        if (immediate)
+        var icon = Button.GetNodeOrNull<TextureRect>("%Icon");
+        if (icon != null)
         {
-            Scale = targetScale;
-            _hsv.SetShaderParameter(S, targetS);
-            _hsv.SetShaderParameter(V, targetV);
-            return;
+            icon.Texture = ResourceLoader.Load<Texture2D>(Entry.ButtonIconPath);
         }
 
-        _hoverTween?.Kill();
-        _hoverTween = CreateTween().SetParallel();
-        _hoverTween.TweenProperty(this, "scale", targetScale, 0.5f)
-            .SetEase(Tween.EaseType.Out)
-            .SetTrans(Tween.TransitionType.Expo);
-        _hoverTween.TweenMethod(Callable.From<float>(UpdateShaderS), _hsv.GetShaderParameter(S), targetS, 0.5f)
-            .SetEase(Tween.EaseType.Out)
-            .SetTrans(Tween.TransitionType.Expo);
-        _hoverTween.TweenMethod(Callable.From<float>(UpdateShaderV), _hsv.GetShaderParameter(V), targetV, 0.5f)
-            .SetEase(Tween.EaseType.Out)
-            .SetTrans(Tween.TransitionType.Expo);
+        var iconAdd = Button.GetNodeOrNull<TextureRect>("%IconAdd");
+        if (iconAdd != null)
+        {
+            iconAdd.Texture = icon?.Texture;
+        }
+
+        var lockIcon = Button.GetNodeOrNull<TextureRect>("%Lock");
+        if (lockIcon != null)
+        {
+            lockIcon.Visible = false;
+        }
     }
 
-    private void UpdateShaderS(float value)
+    private sealed class PlaceholderCharacter : CustomCharacterModel
     {
-        _hsv?.SetShaderParameter(S, value);
-    }
+        private static CharacterModel Template => ModelDb.Character<Ironclad>();
 
-    private void UpdateShaderV(float value)
-    {
-        _hsv?.SetShaderParameter(V, value);
+        public override List<(string, string)>? Localization => [];
+        public override bool HideFromVanillaCharacterSelect => true;
+        public override bool AllowInVanillaRandomCharacterSelect => false;
+        public override Color NameColor => Template.NameColor;
+        public override CharacterGender Gender => Template.Gender;
+        protected override CharacterModel? UnlocksAfterRunAs => null;
+        public override int StartingHp => Template.StartingHp;
+        public override int StartingGold => Template.StartingGold;
+        public override CardPoolModel CardPool => Template.CardPool;
+        public override RelicPoolModel RelicPool => Template.RelicPool;
+        public override PotionPoolModel PotionPool => Template.PotionPool;
+        public override IEnumerable<CardModel> StartingDeck => Template.StartingDeck;
+        public override IReadOnlyList<RelicModel> StartingRelics => Template.StartingRelics;
+        public override float AttackAnimDelay => Template.AttackAnimDelay;
+        public override float CastAnimDelay => Template.CastAnimDelay;
+        public override string? CustomCharacterSelectBg => Template.CharacterSelectBg;
+        public override string? CustomCharacterSelectIconPath => "res://images/packed/character_select/char_select_ironclad.png";
+        public override string? CustomCharacterSelectLockedIconPath => "res://images/packed/character_select/char_select_ironclad_locked.png";
+        public override string? CustomCharacterSelectTransitionPath => Template.CharacterSelectTransitionPath;
+
+        public override List<string> GetArchitectAttackVfx()
+        {
+            return [.. Template.GetArchitectAttackVfx()];
+        }
     }
 }

--- a/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
+++ b/BaseLibScenes/NCustomCharacterSelectEntryButton.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using BaseLib.Abstracts;
 using Godot;
 using HarmonyLib;
-using MegaCrit.Sts2.Core.Entities.Characters;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Models.Characters;
 using MegaCrit.Sts2.Core.Multiplayer.Game.Lobby;
@@ -20,7 +19,6 @@ internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButton
     private static readonly FieldInfo? DelegateField = AccessTools.Field(typeof(NCharacterSelectButton), "_delegate");
     private static readonly FieldInfo? CharacterField = AccessTools.Field(typeof(NCharacterSelectButton), "_character");
     private static readonly FieldInfo? LockedField = AccessTools.Field(typeof(NCharacterSelectButton), "_isLocked");
-    private static readonly PlaceholderCharacter TemplateCharacter = new();
 
     private readonly NCharacterSelectScreen _screen;
     private readonly Action<NCustomCharacterSelectEntryButton> _onSelected;
@@ -135,38 +133,8 @@ internal sealed class NCustomCharacterSelectEntryButton : ICharacterSelectButton
 
     private void UpdateInteractionState()
     {
-        CharacterField?.SetValue(Button, LockSourceCharacter ?? TemplateCharacter);
+        CharacterField?.SetValue(Button, LockSourceCharacter ?? ModelDb.Character<Ironclad>());
         LockedField?.SetValue(Button, !Entry.UnlockedInCharacterSelect);
         ApplyVisuals();
-    }
-
-    private sealed class PlaceholderCharacter : CustomCharacterModel
-    {
-        private static CharacterModel Template => ModelDb.Character<Ironclad>();
-
-        public override List<(string, string)>? Localization => [];
-        public override bool HideFromVanillaCharacterSelect => true;
-        public override bool AllowInVanillaRandomCharacterSelect => false;
-        public override Color NameColor => Template.NameColor;
-        public override CharacterGender Gender => Template.Gender;
-        protected override CharacterModel? UnlocksAfterRunAs => null;
-        public override int StartingHp => Template.StartingHp;
-        public override int StartingGold => Template.StartingGold;
-        public override CardPoolModel CardPool => Template.CardPool;
-        public override RelicPoolModel RelicPool => Template.RelicPool;
-        public override PotionPoolModel PotionPool => Template.PotionPool;
-        public override IEnumerable<CardModel> StartingDeck => Template.StartingDeck;
-        public override IReadOnlyList<RelicModel> StartingRelics => Template.StartingRelics;
-        public override float AttackAnimDelay => Template.AttackAnimDelay;
-        public override float CastAnimDelay => Template.CastAnimDelay;
-        public override string? CustomCharacterSelectBg => Template.CharacterSelectBg;
-        public override string? CustomCharacterSelectIconPath => "res://images/packed/character_select/char_select_ironclad.png";
-        public override string? CustomCharacterSelectLockedIconPath => "res://images/packed/character_select/char_select_ironclad_locked.png";
-        public override string? CustomCharacterSelectTransitionPath => Template.CharacterSelectTransitionPath;
-
-        public override List<string> GetArchitectAttackVfx()
-        {
-            return [.. Template.GetArchitectAttackVfx()];
-        }
     }
 }

--- a/Patches/UI/CustomCharacterSelectEntryPatch.cs
+++ b/Patches/UI/CustomCharacterSelectEntryPatch.cs
@@ -132,28 +132,6 @@ internal static class CustomCharacterSelectEntryPatch
 
     private static void SelectCustomEntry(NCharacterSelectScreen screen, NCustomCharacterSelectEntryButton button)
     {
-        Control entryScene;
-        try
-        {
-            entryScene = button.Entry.CreateCharacterSelectScene();
-        }
-        catch (Exception e)
-        {
-            BaseLibMain.Logger.Error($"Failed to create custom character select scene for {button.Entry.EntryId}: {e}");
-            button.Deselect();
-            return;
-        }
-
-        Control? foregroundScene = null;
-        try
-        {
-            foregroundScene = button.Entry.CreateCharacterSelectForegroundScene();
-        }
-        catch (Exception e)
-        {
-            BaseLibMain.Logger.Error($"Failed to create custom character select foreground scene for {button.Entry.EntryId}: {e}");
-        }
-
         var state = ScreenStates.Get(screen)!;
         var customButtons = state.Buttons.Select(static customButton => customButton.Button).ToHashSet();
 
@@ -175,6 +153,35 @@ internal static class CustomCharacterSelectEntryPatch
 
         ClearBackground(screen);
         ClearActiveEntry(screen, clearScene: true);
+
+        if (button.IsLocked)
+        {
+            state.ActiveButton = button;
+            ApplyLockedEntryPanel(screen, button);
+            return;
+        }
+
+        Control entryScene;
+        try
+        {
+            entryScene = button.Entry.CreateCharacterSelectScene();
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Error($"Failed to create custom character select scene for {button.Entry.EntryId}: {e}");
+            button.Deselect();
+            return;
+        }
+
+        Control? foregroundScene = null;
+        try
+        {
+            foregroundScene = button.Entry.CreateCharacterSelectForegroundScene();
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Error($"Failed to create custom character select foreground scene for {button.Entry.EntryId}: {e}");
+        }
 
         entryScene.Name = $"{button.Entry.EntryId}_entry_bg";
         screen._bgContainer.AddChildSafely(entryScene);
@@ -382,6 +389,31 @@ internal static class CustomCharacterSelectEntryPatch
         screen._relicDescription.Text = string.Empty;
         screen._ascensionPanel.Visible = false;
         ApplyInfoPanelVisibility(screen, entry.ShowVanillaInfoPanelWhenUnresolved);
+    }
+
+    private static void ApplyLockedEntryPanel(NCharacterSelectScreen screen, NCustomCharacterSelectEntryButton button)
+    {
+        if (button.LockSourceCharacter != null)
+        {
+            ApplyLockedCharacterPanel(
+                screen,
+                button.LockSourceCharacter,
+                button.Entry.ShowVanillaInfoPanelWhenUnresolved);
+            return;
+        }
+
+        screen._selectedButton = null;
+        screen._embarkButton.Disable();
+        screen._name.SetTextAutoSize(button.Entry.LockedTitle);
+        screen._description.Text = button.Entry.LockedDescription;
+        screen._hp.SetTextAutoSize("??/??");
+        screen._gold.SetTextAutoSize("???");
+        screen._relicIcon.SelfModulate = StsColors.transparentBlack;
+        screen._relicIconOutline.SelfModulate = StsColors.transparentBlack;
+        screen._relicTitle.Text = string.Empty;
+        screen._relicDescription.Text = string.Empty;
+        screen._ascensionPanel.Visible = false;
+        ApplyInfoPanelVisibility(screen, button.Entry.ShowVanillaInfoPanelWhenUnresolved);
     }
 
     private static void ApplyCharacterPanel(

--- a/Patches/UI/CustomCharacterSelectEntryPatch.cs
+++ b/Patches/UI/CustomCharacterSelectEntryPatch.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BaseLib.Abstracts;
+using BaseLib.BaseLibScenes;
+using BaseLib.Extensions;
+using BaseLib.Utils;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Helpers;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Characters;
+using MegaCrit.Sts2.Core.Multiplayer.Game;
+using MegaCrit.Sts2.Core.Nodes.Screens.CharacterSelect;
+using MegaCrit.Sts2.Core.Saves;
+
+namespace BaseLib.Patches.UI;
+
+[HarmonyPatch]
+internal static class CustomCharacterSelectEntryPatch
+{
+    private static readonly SpireField<NCharacterSelectScreen, CustomCharacterSelectScreenState> ScreenStates = new(() => new());
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), "InitCharacterButtons")]
+    [HarmonyPostfix]
+    private static void AddCustomEntryButtons(NCharacterSelectScreen __instance)
+    {
+        if (CustomCharacterSelectEntryRegistry.Entries.Count == 0) return;
+
+        var state = ScreenStates.Get(__instance)!;
+        if (state.Initialized) return;
+        state.Initialized = true;
+
+        var randomButton = __instance._randomCharacterButton;
+        if (randomButton?.GetParent() == __instance._charButtonContainer)
+        {
+            __instance._charButtonContainer.RemoveChildSafely(randomButton);
+        }
+
+        foreach (var entry in CustomCharacterSelectEntryRegistry.Entries)
+        {
+            if (!entry.VisibleInCharacterSelect) continue;
+
+            var button = new NCustomCharacterSelectEntryButton();
+            button.Name = $"{entry.EntryId}_entry_button";
+            button.Initialize(entry, selected => SelectCustomEntry(__instance, selected));
+            __instance._charButtonContainer.AddChildSafely(button);
+            state.Buttons.Add(button);
+        }
+
+        if (randomButton != null)
+        {
+            __instance._charButtonContainer.AddChildSafely(randomButton);
+        }
+
+        RebuildFocusNeighbors(__instance);
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), nameof(NCharacterSelectScreen.OnSubmenuOpened))]
+    [HarmonyPostfix]
+    private static void OnSubmenuOpenedPostfix(NCharacterSelectScreen __instance)
+    {
+        var state = ScreenStates.Get(__instance);
+        if (state == null) return;
+
+        foreach (var button in state.Buttons)
+        {
+            button.Enable();
+            button.Deselect();
+        }
+
+        ClearActiveEntry(__instance, clearScene: true);
+        RebuildFocusNeighbors(__instance);
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), nameof(NCharacterSelectScreen.OnSubmenuClosed))]
+    [HarmonyPrefix]
+    private static void OnSubmenuClosedPrefix(NCharacterSelectScreen __instance)
+    {
+        ClearActiveEntry(__instance, clearScene: true);
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), nameof(NCharacterSelectScreen.SelectCharacter))]
+    [HarmonyPostfix]
+    private static void SelectCharacterPostfix(NCharacterSelectScreen __instance)
+    {
+        ClearActiveEntry(__instance, clearScene: false);
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), "OnEmbarkPressed")]
+    [HarmonyPrefix]
+    private static bool OnEmbarkPressedPrefix(NCharacterSelectScreen __instance)
+    {
+        var state = ScreenStates.Get(__instance);
+        if (state?.ActiveButton == null) return true;
+        if (state.Context?.SelectedCharacter is { } character && !IsCharacterLocked(character)) return true;
+
+        __instance._embarkButton.Disable();
+        return false;
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), "OnEmbarkPressed")]
+    [HarmonyPostfix]
+    private static void OnEmbarkPressedPostfix(NCharacterSelectScreen __instance)
+    {
+        var state = ScreenStates.Get(__instance);
+        if (state == null || !__instance.Lobby.LocalPlayer.isReady) return;
+
+        foreach (var button in state.Buttons)
+        {
+            button.Disable();
+        }
+    }
+
+    [HarmonyPatch(typeof(NCharacterSelectScreen), "OnUnreadyPressed")]
+    [HarmonyPostfix]
+    private static void OnUnreadyPressedPostfix(NCharacterSelectScreen __instance)
+    {
+        var state = ScreenStates.Get(__instance);
+        if (state == null) return;
+
+        foreach (var button in state.Buttons)
+        {
+            button.Enable();
+        }
+
+        state.ActiveButton?.TryGrabFocus();
+        RefreshEmbarkAvailability(__instance);
+    }
+
+    private static void SelectCustomEntry(NCharacterSelectScreen screen, NCustomCharacterSelectEntryButton button)
+    {
+        if (button.Entry == null) return;
+
+        Control entryScene;
+        try
+        {
+            entryScene = button.Entry.CreateCharacterSelectScene();
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Error($"Failed to create custom character select scene for {button.Entry.EntryId}: {e}");
+            button.Deselect();
+            return;
+        }
+
+        var state = ScreenStates.Get(screen)!;
+
+        foreach (var vanillaButton in screen._charButtonContainer.GetChildren().OfType<NCharacterSelectButton>())
+        {
+            vanillaButton.Deselect();
+        }
+
+        foreach (var customButton in state.Buttons)
+        {
+            if (customButton != button)
+            {
+                customButton.Deselect();
+            }
+        }
+
+        ClearBackground(screen);
+        ClearActiveEntry(screen, clearScene: true);
+
+        entryScene.Name = $"{button.Entry.EntryId}_entry_bg";
+        screen._bgContainer.AddChildSafely(entryScene);
+
+        CustomCharacterSelectContext? context = null;
+        context = new CustomCharacterSelectContext(
+            button.Entry,
+            screen,
+            entryScene,
+            character => OnResolvedCharacterChanged(screen, context!, character));
+
+        state.ActiveButton = button;
+        state.ActiveScene = entryScene;
+        state.Context = context;
+
+        ApplyEntryPanel(screen, button.Entry);
+
+        try
+        {
+            button.Entry.RegisterScene(entryScene, context);
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Error($"Failed to register custom character select scene for {button.Entry.EntryId}: {e}");
+        }
+
+        if (context.SelectedCharacter == null && button.Entry.InitialCharacter is { } initialCharacter)
+        {
+            context.SetCharacter(initialCharacter);
+        }
+        else
+        {
+            RefreshEmbarkAvailability(screen);
+        }
+    }
+
+    private static void OnResolvedCharacterChanged(
+        NCharacterSelectScreen screen,
+        CustomCharacterSelectContext context,
+        CharacterModel? character)
+    {
+        var state = ScreenStates.Get(screen);
+        if (state?.Context != context) return;
+
+        if (character == null)
+        {
+            ApplyEntryPanel(screen, context.Entry);
+            RefreshEmbarkAvailability(screen);
+            return;
+        }
+
+        ApplyCharacterPanel(screen, character);
+    }
+
+    private static void RefreshEmbarkAvailability(NCharacterSelectScreen screen)
+    {
+        var state = ScreenStates.Get(screen);
+        if (state?.ActiveButton == null) return;
+
+        if (state.Context?.SelectedCharacter == null)
+        {
+            screen._embarkButton.Disable();
+        }
+        else if (IsCharacterLocked(state.Context.SelectedCharacter))
+        {
+            screen._embarkButton.Disable();
+        }
+        else
+        {
+            screen._embarkButton.Enable();
+        }
+    }
+
+    private static void ClearActiveEntry(NCharacterSelectScreen screen, bool clearScene)
+    {
+        var state = ScreenStates.Get(screen);
+        if (state == null) return;
+
+        state.ActiveButton?.Deselect();
+
+        if (clearScene && state.ActiveScene != null && GodotObject.IsInstanceValid(state.ActiveScene))
+        {
+            if (state.ActiveScene.GetParent() != null)
+            {
+                state.ActiveScene.GetParent().RemoveChildSafely(state.ActiveScene);
+            }
+
+            state.ActiveScene.QueueFreeSafely();
+        }
+
+        state.ActiveButton = null;
+        state.ActiveScene = null;
+        state.Context = null;
+    }
+
+    private static void ClearBackground(NCharacterSelectScreen screen)
+    {
+        foreach (Node child in screen._bgContainer.GetChildren())
+        {
+            screen._bgContainer.RemoveChildSafely(child);
+            child.QueueFreeSafely();
+        }
+    }
+
+    private static void RebuildFocusNeighbors(NCharacterSelectScreen screen)
+    {
+        var buttons = screen._charButtonContainer.GetChildren()
+            .OfType<Control>()
+            .Where(static c => c.Visible)
+            .ToList();
+
+        if (buttons.Count == 0) return;
+
+        for (var i = 0; i < buttons.Count; i++)
+        {
+            var current = buttons[i];
+            current.FocusNeighborTop = current.GetPath();
+            current.FocusNeighborBottom = current.GetPath();
+            current.FocusNeighborLeft = buttons[(i - 1 + buttons.Count) % buttons.Count].GetPath();
+            current.FocusNeighborRight = buttons[(i + 1) % buttons.Count].GetPath();
+        }
+    }
+
+    private static void AnimateInfoPanel(NCharacterSelectScreen screen)
+    {
+        if (screen._infoPanelTween != null)
+        {
+            screen._infoPanel.Position = screen._infoPanelPosFinalVal;
+        }
+
+        screen._infoPanelPosFinalVal = screen._infoPanel.Position;
+        screen._infoPanelTween?.Kill();
+        screen._infoPanelTween = screen.CreateTween().SetParallel();
+        screen._infoPanelTween.TweenProperty(screen._infoPanel, "position", screen._infoPanel.Position, 0.5)
+            .SetEase(Tween.EaseType.Out)
+            .SetTrans(Tween.TransitionType.Expo)
+            .From(screen._infoPanel.Position - new Vector2(300f, 0f));
+    }
+
+    private static void ApplyEntryPanel(NCharacterSelectScreen screen, CustomCharacterSelectEntry entry)
+    {
+        AnimateInfoPanel(screen);
+        screen._selectedButton = null;
+        screen._embarkButton.Disable();
+        screen._name.SetTextAutoSize(entry.EntryTitle);
+        screen._description.Text = entry.EntryDescription;
+        screen._hp.SetTextAutoSize("??/??");
+        screen._gold.SetTextAutoSize("???");
+        screen._relicIcon.SelfModulate = StsColors.transparentBlack;
+        screen._relicIconOutline.SelfModulate = StsColors.transparentBlack;
+        screen._relicTitle.Text = string.Empty;
+        screen._relicDescription.Text = string.Empty;
+        screen._ascensionPanel.Visible = false;
+    }
+
+    private static void ApplyCharacterPanel(NCharacterSelectScreen screen, CharacterModel character)
+    {
+        AnimateInfoPanel(screen);
+        screen._selectedButton = null;
+
+        if (IsCharacterLocked(character))
+        {
+            ApplyLockedCharacterPanel(screen, character);
+            return;
+        }
+
+        var formattedTitle = new LocString("characters", character.CharacterSelectTitle).GetFormattedText();
+        screen._name.SetTextAutoSize(formattedTitle);
+        screen._description.Text = new LocString("characters", character.CharacterSelectDesc).GetFormattedText();
+
+        if (character is not RandomCharacter)
+        {
+            screen._hp.SetTextAutoSize($"{character.StartingHp}/{character.StartingHp}");
+            screen._gold.SetTextAutoSize($"{character.StartingGold}");
+            var relic = character.StartingRelics[0];
+            screen._relicTitle.Text = relic.Title.GetFormattedText();
+            screen._relicDescription.Text = relic.DynamicDescription.GetFormattedText();
+            screen._relicIcon.Texture = relic.Icon;
+            screen._relicIconOutline.Texture = relic.IconOutline;
+            screen._relicIcon.SelfModulate = Colors.White;
+            screen._relicIconOutline.SelfModulate = StsColors.halfTransparentBlack;
+        }
+        else
+        {
+            screen._hp.SetTextAutoSize("??/??");
+            screen._gold.SetTextAutoSize("???");
+            screen._relicIcon.SelfModulate = StsColors.transparentBlack;
+            screen._relicIconOutline.SelfModulate = StsColors.transparentBlack;
+            screen._relicTitle.Text = string.Empty;
+            screen._relicDescription.Text = string.Empty;
+        }
+
+        screen._embarkButton.Enable();
+        screen._lobby.SetLocalCharacter(character);
+        if (!screen._lobby.NetService.Type.IsMultiplayer())
+        {
+            screen._ascensionPanel.AnimIn();
+        }
+    }
+
+    private static void ApplyLockedCharacterPanel(NCharacterSelectScreen screen, CharacterModel character)
+    {
+        screen._embarkButton.Disable();
+        screen._name.SetTextAutoSize(new LocString("main_menu_ui", "CHARACTER_SELECT.locked.title").GetFormattedText());
+        screen._description.Text = character.GetUnlockText().GetFormattedText();
+        screen._hp.SetTextAutoSize("??/??");
+        screen._gold.SetTextAutoSize("???");
+
+        if (character is not RandomCharacter)
+        {
+            var relic = character.StartingRelics[0];
+            screen._relicTitle.Text = new LocString("main_menu_ui", "CHARACTER_SELECT.lockedRelic.title").GetFormattedText();
+            screen._relicDescription.Text =
+                new LocString("main_menu_ui", "CHARACTER_SELECT.lockedRelic.description").GetFormattedText();
+            screen._relicIcon.Texture = relic.Icon;
+            screen._relicIconOutline.Texture = relic.IconOutline;
+            screen._relicIcon.SelfModulate = StsColors.ninetyPercentBlack;
+            screen._relicIconOutline.SelfModulate = StsColors.halfTransparentWhite;
+        }
+        else
+        {
+            screen._relicIcon.SelfModulate = StsColors.transparentBlack;
+            screen._relicIconOutline.SelfModulate = StsColors.transparentBlack;
+            screen._relicTitle.Text = string.Empty;
+            screen._relicDescription.Text = string.Empty;
+        }
+
+        screen._ascensionPanel.Visible = false;
+    }
+
+    private static bool IsCharacterLocked(CharacterModel character)
+    {
+        if (character is RandomCharacter)
+        {
+            var unlockState = SaveManager.Instance.GenerateUnlockStateFromProgress();
+            return ModelDb.AllCharacters.Any(c => !unlockState.Characters.Contains(c));
+        }
+
+        return !SaveManager.Instance.GenerateUnlockStateFromProgress().Characters.Contains(character);
+    }
+
+    private sealed class CustomCharacterSelectScreenState
+    {
+        public bool Initialized { get; set; }
+        public List<NCustomCharacterSelectEntryButton> Buttons { get; } = [];
+        public NCustomCharacterSelectEntryButton? ActiveButton { get; set; }
+        public Control? ActiveScene { get; set; }
+        public CustomCharacterSelectContext? Context { get; set; }
+    }
+}

--- a/Patches/UI/CustomCharacterSelectEntryPatch.cs
+++ b/Patches/UI/CustomCharacterSelectEntryPatch.cs
@@ -42,10 +42,8 @@ internal static class CustomCharacterSelectEntryPatch
         {
             if (!entry.VisibleInCharacterSelect) continue;
 
-            var button = new NCustomCharacterSelectEntryButton();
-            button.Name = $"{entry.EntryId}_entry_button";
-            button.Initialize(entry, selected => SelectCustomEntry(__instance, selected));
-            __instance._charButtonContainer.AddChildSafely(button);
+            var button = new NCustomCharacterSelectEntryButton(entry, __instance, selected => SelectCustomEntry(__instance, selected));
+            __instance._charButtonContainer.AddChildSafely(button.Button);
             state.Buttons.Add(button);
         }
 
@@ -54,6 +52,7 @@ internal static class CustomCharacterSelectEntryPatch
             __instance._charButtonContainer.AddChildSafely(randomButton);
         }
 
+        EnsureForegroundContainer(__instance, state);
         RebuildFocusNeighbors(__instance);
     }
 
@@ -71,6 +70,7 @@ internal static class CustomCharacterSelectEntryPatch
         }
 
         ClearActiveEntry(__instance, clearScene: true);
+        __instance._infoPanel.Visible = true;
         RebuildFocusNeighbors(__instance);
     }
 
@@ -86,6 +86,7 @@ internal static class CustomCharacterSelectEntryPatch
     private static void SelectCharacterPostfix(NCharacterSelectScreen __instance)
     {
         ClearActiveEntry(__instance, clearScene: false);
+        __instance._infoPanel.Visible = true;
     }
 
     [HarmonyPatch(typeof(NCharacterSelectScreen), "OnEmbarkPressed")]
@@ -131,8 +132,6 @@ internal static class CustomCharacterSelectEntryPatch
 
     private static void SelectCustomEntry(NCharacterSelectScreen screen, NCustomCharacterSelectEntryButton button)
     {
-        if (button.Entry == null) return;
-
         Control entryScene;
         try
         {
@@ -145,11 +144,25 @@ internal static class CustomCharacterSelectEntryPatch
             return;
         }
 
+        Control? foregroundScene = null;
+        try
+        {
+            foregroundScene = button.Entry.CreateCharacterSelectForegroundScene();
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Error($"Failed to create custom character select foreground scene for {button.Entry.EntryId}: {e}");
+        }
+
         var state = ScreenStates.Get(screen)!;
+        var customButtons = state.Buttons.Select(static customButton => customButton.Button).ToHashSet();
 
         foreach (var vanillaButton in screen._charButtonContainer.GetChildren().OfType<NCharacterSelectButton>())
         {
-            vanillaButton.Deselect();
+            if (!customButtons.Contains(vanillaButton))
+            {
+                vanillaButton.Deselect();
+            }
         }
 
         foreach (var customButton in state.Buttons)
@@ -166,15 +179,23 @@ internal static class CustomCharacterSelectEntryPatch
         entryScene.Name = $"{button.Entry.EntryId}_entry_bg";
         screen._bgContainer.AddChildSafely(entryScene);
 
+        if (foregroundScene != null)
+        {
+            foregroundScene.Name = $"{button.Entry.EntryId}_entry_fg";
+            EnsureForegroundContainer(screen, state).AddChildSafely(foregroundScene);
+        }
+
         CustomCharacterSelectContext? context = null;
         context = new CustomCharacterSelectContext(
             button.Entry,
             screen,
             entryScene,
+            foregroundScene,
             character => OnResolvedCharacterChanged(screen, context!, character));
 
         state.ActiveButton = button;
         state.ActiveScene = entryScene;
+        state.ActiveForegroundScene = foregroundScene;
         state.Context = context;
 
         ApplyEntryPanel(screen, button.Entry);
@@ -186,6 +207,18 @@ internal static class CustomCharacterSelectEntryPatch
         catch (Exception e)
         {
             BaseLibMain.Logger.Error($"Failed to register custom character select scene for {button.Entry.EntryId}: {e}");
+        }
+
+        if (foregroundScene != null)
+        {
+            try
+            {
+                button.Entry.RegisterForegroundScene(foregroundScene, context);
+            }
+            catch (Exception e)
+            {
+                BaseLibMain.Logger.Error($"Failed to register custom character select foreground scene for {button.Entry.EntryId}: {e}");
+            }
         }
 
         if (context.SelectedCharacter == null && button.Entry.InitialCharacter is { } initialCharacter)
@@ -213,7 +246,7 @@ internal static class CustomCharacterSelectEntryPatch
             return;
         }
 
-        ApplyCharacterPanel(screen, character);
+        ApplyCharacterPanel(screen, character, context.Entry);
     }
 
     private static void RefreshEmbarkAvailability(NCharacterSelectScreen screen)
@@ -252,8 +285,19 @@ internal static class CustomCharacterSelectEntryPatch
             state.ActiveScene.QueueFreeSafely();
         }
 
+        if (clearScene && state.ActiveForegroundScene != null && GodotObject.IsInstanceValid(state.ActiveForegroundScene))
+        {
+            if (state.ActiveForegroundScene.GetParent() != null)
+            {
+                state.ActiveForegroundScene.GetParent().RemoveChildSafely(state.ActiveForegroundScene);
+            }
+
+            state.ActiveForegroundScene.QueueFreeSafely();
+        }
+
         state.ActiveButton = null;
         state.ActiveScene = null;
+        state.ActiveForegroundScene = null;
         state.Context = null;
     }
 
@@ -264,6 +308,29 @@ internal static class CustomCharacterSelectEntryPatch
             screen._bgContainer.RemoveChildSafely(child);
             child.QueueFreeSafely();
         }
+    }
+
+    private static Control EnsureForegroundContainer(
+        NCharacterSelectScreen screen,
+        CustomCharacterSelectScreenState state)
+    {
+        if (state.ForegroundContainer != null && GodotObject.IsInstanceValid(state.ForegroundContainer))
+        {
+            screen.MoveChild(state.ForegroundContainer, screen.GetChildCount() - 1);
+            return state.ForegroundContainer;
+        }
+
+        var container = new Control
+        {
+            Name = "BaseLibCharacterSelectForeground",
+            LayoutMode = 1,
+            MouseFilter = Control.MouseFilterEnum.Ignore
+        };
+        container.SetAnchorsPreset(Control.LayoutPreset.FullRect);
+        screen.AddChildSafely(container);
+        screen.MoveChild(container, screen.GetChildCount() - 1);
+        state.ForegroundContainer = container;
+        return container;
     }
 
     private static void RebuildFocusNeighbors(NCharacterSelectScreen screen)
@@ -303,7 +370,6 @@ internal static class CustomCharacterSelectEntryPatch
 
     private static void ApplyEntryPanel(NCharacterSelectScreen screen, CustomCharacterSelectEntry entry)
     {
-        AnimateInfoPanel(screen);
         screen._selectedButton = null;
         screen._embarkButton.Disable();
         screen._name.SetTextAutoSize(entry.EntryTitle);
@@ -315,16 +381,19 @@ internal static class CustomCharacterSelectEntryPatch
         screen._relicTitle.Text = string.Empty;
         screen._relicDescription.Text = string.Empty;
         screen._ascensionPanel.Visible = false;
+        ApplyInfoPanelVisibility(screen, entry.ShowVanillaInfoPanelWhenUnresolved);
     }
 
-    private static void ApplyCharacterPanel(NCharacterSelectScreen screen, CharacterModel character)
+    private static void ApplyCharacterPanel(
+        NCharacterSelectScreen screen,
+        CharacterModel character,
+        CustomCharacterSelectEntry entry)
     {
-        AnimateInfoPanel(screen);
         screen._selectedButton = null;
 
         if (IsCharacterLocked(character))
         {
-            ApplyLockedCharacterPanel(screen, character);
+            ApplyLockedCharacterPanel(screen, character, entry.ShowVanillaInfoPanelWhenResolved);
             return;
         }
 
@@ -360,9 +429,14 @@ internal static class CustomCharacterSelectEntryPatch
         {
             screen._ascensionPanel.AnimIn();
         }
+
+        ApplyInfoPanelVisibility(screen, entry.ShowVanillaInfoPanelWhenResolved);
     }
 
-    private static void ApplyLockedCharacterPanel(NCharacterSelectScreen screen, CharacterModel character)
+    private static void ApplyLockedCharacterPanel(
+        NCharacterSelectScreen screen,
+        CharacterModel character,
+        bool showInfoPanel)
     {
         screen._embarkButton.Disable();
         screen._name.SetTextAutoSize(new LocString("main_menu_ui", "CHARACTER_SELECT.locked.title").GetFormattedText());
@@ -390,17 +464,29 @@ internal static class CustomCharacterSelectEntryPatch
         }
 
         screen._ascensionPanel.Visible = false;
+        ApplyInfoPanelVisibility(screen, showInfoPanel);
+    }
+
+    private static void ApplyInfoPanelVisibility(NCharacterSelectScreen screen, bool visible)
+    {
+        screen._infoPanel.Visible = visible;
+        if (visible)
+        {
+            AnimateInfoPanel(screen);
+        }
     }
 
     private static bool IsCharacterLocked(CharacterModel character)
     {
+        var unlockState = SaveManager.Instance.GenerateUnlockStateFromProgress();
         if (character is RandomCharacter)
         {
-            var unlockState = SaveManager.Instance.GenerateUnlockStateFromProgress();
-            return ModelDb.AllCharacters.Any(c => !unlockState.Characters.Contains(c));
+            return ModelDb.AllCharacters
+                .Where(static c => c is not CustomCharacterModel { AllowInVanillaRandomCharacterSelect: false })
+                .Any(c => !unlockState.Characters.Contains(c));
         }
 
-        return !SaveManager.Instance.GenerateUnlockStateFromProgress().Characters.Contains(character);
+        return !unlockState.Characters.Contains(character);
     }
 
     private sealed class CustomCharacterSelectScreenState
@@ -409,6 +495,8 @@ internal static class CustomCharacterSelectEntryPatch
         public List<NCustomCharacterSelectEntryButton> Buttons { get; } = [];
         public NCustomCharacterSelectEntryButton? ActiveButton { get; set; }
         public Control? ActiveScene { get; set; }
+        public Control? ActiveForegroundScene { get; set; }
+        public Control? ForegroundContainer { get; set; }
         public CustomCharacterSelectContext? Context { get; set; }
     }
 }


### PR DESCRIPTION
This PR builds upon my previous one (#147), which implemented the ability to hide characters from the character selection screen. However, under that implementation, developers still had to build their own custom selection buttons entirely from scratch. I felt it made sense to tackle this simultaneously, which led to the creation of this PR.

The core feature introduced here is the ability to add "non-character" selection buttons to the character list. When selected, these buttons do not immediately start the game. Instead, they instantiate a developer-defined scene (either from a loaded .tscn file or a dynamically constructed node tree). This custom scene is then used to display the developer's bespoke character selection logic and handle the final transition into the game.