### PR TITLE
Add Invert option to Custom Temporary Powers

### DIFF
--- a/Abstracts/CustomTemporaryPowerModel.cs
+++ b/Abstracts/CustomTemporaryPowerModel.cs
@@ -32,7 +32,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
     public override PowerStackType StackType => PowerStackType.Counter;
     public override bool AllowNegative => true;
     public override bool IsInstanced => LastForXExtraTurns != 0;
-    
+    protected virtual bool InvertInternalPowerAmount => false;
     
     // The whole IgnoreNextInstance thing ONLY exists because of the Misery card
     // Check Misery.DoHackyThingsForSpecificPowers() for usage
@@ -59,7 +59,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
         {
             DynamicVars.Repeat.BaseValue = LastForXExtraTurns;
             DynamicVars[LocTurnEndBoolVar].BaseValue = Convert.ToDecimal(UntilEndOfOtherSideTurn);
-            await ApplyPowerFunc(new ThrowingPlayerChoiceContext(), target, amount, applier, cardSource, true);
+            await ApplyPowerFunc(new ThrowingPlayerChoiceContext(), target, InvertInternalPowerAmount ? -amount : amount, applier, cardSource, true);
         }
     }
 
@@ -74,7 +74,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
         if (powerSource._shouldIgnoreNextInstance)
             powerSource._shouldIgnoreNextInstance = false;
         else
-            await ApplyPowerFunc(context, powerSource.Owner, amount, applier, cardSource, true);
+            await ApplyPowerFunc(context, powerSource.Owner, InvertInternalPowerAmount ? -amount : amount, applier, cardSource, true);
     }
 
 
@@ -95,7 +95,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
         }
 
         powerSource.Flash();
-        await ApplyPowerFunc(choiceContext, powerSource.Owner, -powerSource.Amount, powerSource.Owner, null, true);
+        await ApplyPowerFunc(choiceContext, powerSource.Owner, InvertInternalPowerAmount ? powerSource.Amount : -powerSource.Amount, powerSource.Owner, null, true);
         await PowerCmd.Remove(powerSource);
     }
 

--- a/Abstracts/CustomTemporaryPowerModelWrapper.cs
+++ b/Abstracts/CustomTemporaryPowerModelWrapper.cs
@@ -14,15 +14,15 @@ namespace BaseLib.Abstracts;
 /// <typeparam name="TPower">The power that will be applied to the target</typeparam>
 public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomTemporaryPowerModel  where TModel : AbstractModel where TPower : PowerModel
 {
-    public override string CustomBigBetaIconPath => (Amount >= 0 ? "BaseLib/images/powers/big/baselib-power_temp_up.png" : "BaseLib/images/powers/big/baselib-power_temp_down.png");
+    public override string CustomBigBetaIconPath => (Amount >= 0 == !InvertInternalPowerAmount ? "BaseLib/images/powers/big/baselib-power_temp_up.png" : "BaseLib/images/powers/big/baselib-power_temp_down.png");
     /// <summary>
     /// Placeholder small icon; you are recommended to override this.
     /// </summary>
-    public override string CustomPackedIconPath => (Amount >= 0 ? "BaseLib/images/powers/baselib-power_temp_up.png" : "BaseLib/images/powers/baselib-power_temp_down.png");
+    public override string CustomPackedIconPath => (Amount >= 0 == !InvertInternalPowerAmount ? "BaseLib/images/powers/baselib-power_temp_up.png" : "BaseLib/images/powers/baselib-power_temp_down.png");
     /// <summary>
     /// Placeholder large icon; you are recommended to override this.
     /// </summary>
-    public override string CustomBigIconPath => (Amount >= 0 ? "BaseLib/images/powers/big/baselib-power_temp_up_big.png" : "BaseLib/images/powers/big/baselib-power_temp_down_big.png");
+    public override string CustomBigIconPath => (Amount >= 0 == !InvertInternalPowerAmount ? "BaseLib/images/powers/big/baselib-power_temp_up_big.png" : "BaseLib/images/powers/big/baselib-power_temp_down_big.png");
 
     public override AbstractModel OriginModel => ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>());
     public override PowerModel InternallyAppliedPower => ModelDb.Power<TPower>();
@@ -33,10 +33,7 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
             return BetaMainCompatibility.PowerCmd_.Apply.
                 InvokeGeneric<Task<TPower?>, TPower>(null, context, target, amt, src, srcCard, silent) ?? Task.CompletedTask;
         };
-        
     
-    
-
     
     public override LocString Title
     {
@@ -58,6 +55,8 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     return characterModel.Title;
                 case MonsterModel monsterModel:
                     return monsterModel.Title;
+                case ActModel actModel:
+                    return actModel.Title;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the 'Title' for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet. Using default title.");
                     return new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
@@ -84,6 +83,9 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                 case PowerModel power:
                     items = [HoverTipFactory.FromPower(power)];
                     break;
+                case ActModel:
+                    items = [];
+                    break;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the Hover Tips for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet.");
                     items = [];
@@ -94,8 +96,8 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
         }
     }
 
-    public override LocString Description => new LocString("powers", Amount > 0 ? "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.description" : "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.description");
+    public override LocString Description => new LocString("powers", Amount > 0 == !InvertInternalPowerAmount ? "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.description" : "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.description");
     
-    protected override string SmartDescriptionLocKey => Amount > 0 ? "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription" : "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription";
+    protected override string SmartDescriptionLocKey => Amount > 0 == !InvertInternalPowerAmount ? "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.UP.smartDescription" : "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.DOWN.smartDescription";
 
 }


### PR DESCRIPTION
Add an `InvertInternalPowerAmount` boolean property to the Model.
Adjust Icon and LocString decision logic.
Add `ActModel` support to `Title` and `ExtraHoverTips` in the Wrapper (Acts have no ExtraHoverTips so it will just return an empty list)
***
There was a slight issue with the Model where a TemporaryPower like this (intended for reducing enemy Strength)
```cs
public class Example : CustomTemporaryPowerModelWrapper<SomeSource, StrengthPower>
{
    public override PowerType Type => PowerType.Debuff;
}
```
would lead to inevitable issues with interactions that modify the power amount based on, for example, the PowerType:
```cs
public override decimal ModifyPowerAmountGiven(PowerModel power, Creature giver, decimal amount, Creature? target, CardModel? cardSource)
{
    return amount - (target == Owner && power.Type == PowerType.Debuff ? 1m : 0m);
}
```
Currently one would simply apply a negative amount of the power to reduce strength temporarily. If the PowerType is set to `Debuff` the result of the above interaction would be: Try to apply (for example) -5 amount -> hook sees its a debuff and wants to reduce it by 1 -> now actually applies an amount of -6 which removes more strength than before.

Additionally the base game powers that reduce strength do not apply a negative number for the temporary power, but a positive one (see `Piercing Wail`).

By overriding the `PowerType` to `Debuff` and setting the Invert option to true the temporary powers that apply Buffs like Strength, Dexterity, etc as Debuffs (by reducing them) now properly behave like the base game equivalents and interact properly with modification attempts.

