### PR TITLE
Mod config: add [ConfigIgnoreRestoreDefaults]

### DIFF
--- a/Config/ConfigAttributes.cs
+++ b/Config/ConfigAttributes.cs
@@ -93,6 +93,15 @@ public class ConfigIgnoreAttribute : Attribute;
 public class ConfigHideInUI : Attribute;
 
 /// <summary>
+/// Makes this property ignore Restore Defaults (whether via the button or via
+/// <see cref="ModConfig.RestoreDefaultsNoConfirm"/>).<br/>
+/// Useful if you're storing some kind of persistent state, rather than a user configurable value.<br/>
+/// Works with and without [<see cref="ConfigHideInUI"/>].
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ConfigIgnoreRestoreDefaultsAttribute : Attribute;
+
+/// <summary>
 /// Defines a set of allowed characters for a LineEdit.
 /// </summary>
 public enum TextInputPreset

--- a/Config/ModConfig.cs
+++ b/Config/ModConfig.cs
@@ -155,10 +155,17 @@ public abstract partial class ModConfig
         return default;
     }
 
+    /// <summary>
+    /// Restores the default value for all relevant config properties: all except those marked with
+    /// [<see cref="ConfigIgnoreAttribute">ConfigIgnore</see>] or
+    /// [<see cref="ConfigIgnoreRestoreDefaultsAttribute">ConfigIgnoreRestoreDefaults</see>].
+    /// </summary>
     protected void RestoreDefaultsNoConfirm()
     {
         foreach (var property in ConfigProperties)
         {
+            if (property.GetCustomAttribute<ConfigIgnoreRestoreDefaultsAttribute>() != null) continue;
+
             var defaultValue = GetDefaultValue<object?>(property.Name);
             property.SetValue(null, defaultValue);
         }


### PR DESCRIPTION
Very simple property; useful for e.g. storing persistent state with [ConfigHideInUI]. Such properties are by default reset with the rest when you click Restore Defaults.