### PR TITLE
Add Dusty Tome Compatibility Patch 

### DIFF
--- a/Abstracts/ITomeCard.cs
+++ b/Abstracts/ITomeCard.cs
@@ -1,0 +1,8 @@
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Abstracts;
+
+public interface ITomeCard
+{
+    public CharacterModel GetCharacterModel();
+}

--- a/Patches/Content/DustyTomeCardPatch
+++ b/Patches/Content/DustyTomeCardPatch
@@ -1,0 +1,40 @@
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Players;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Models.Cards;
+using MegaCrit.Sts2.Core.Models.Characters;
+using MegaCrit.Sts2.Core.Models.Relics;
+
+namespace BaseLib.Patches.Content;
+
+[HarmonyPatch(typeof(DustyTome), nameof(DustyTome.SetupForPlayer))]
+public class DarvAncientCardPatch
+{
+    private static Dictionary<CharacterModel, ModelId>? _customTome;
+
+    [HarmonyPostfix]
+    static void DustyTomeCardOverride(DustyTome __instance, Player player)
+    {
+        if (_customTome == null)
+        {
+            _customTome = new()
+            {
+                { ModelDb.Character<Ironclad>(), ModelDb.Card<Corruption>().Id },
+                { ModelDb.Character<Silent>(), ModelDb.Card<WraithForm>().Id },
+                { ModelDb.Character<Regent>(), ModelDb.Card<TheSealedThrone>().Id },
+                { ModelDb.Character<Necrobinder>(), ModelDb.Card<ForbiddenGrimoire>().Id },
+                { ModelDb.Character<Defect>(), ModelDb.Card<BiasedCognition>().Id }
+            };
+            foreach (var cardModel in ModelDb.AllCards)
+            {
+                if (cardModel is ITomeCard target)
+                {
+                    // While this could be handled as an interface of the CharacterModel, I feel it would be better done on the card.
+                    _customTome[target.GetCharacterModel()] = cardModel.Id;
+                }
+            }
+        }
+
+        __instance.AncientCard = _customTome[player.Character];
+    }
+}

--- a/Patches/Content/DustyTomeCardPatch.cs
+++ b/Patches/Content/DustyTomeCardPatch.cs
@@ -17,14 +17,7 @@ public class DarvAncientCardPatch
     {
         if (_customTome == null)
         {
-            _customTome = new()
-            {
-                { ModelDb.Character<Ironclad>(), ModelDb.Card<Corruption>().Id },
-                { ModelDb.Character<Silent>(), ModelDb.Card<WraithForm>().Id },
-                { ModelDb.Character<Regent>(), ModelDb.Card<TheSealedThrone>().Id },
-                { ModelDb.Character<Necrobinder>(), ModelDb.Card<ForbiddenGrimoire>().Id },
-                { ModelDb.Character<Defect>(), ModelDb.Card<BiasedCognition>().Id }
-            };
+            _customTome = [];
             foreach (var cardModel in ModelDb.AllCards)
             {
                 if (cardModel is ITomeCard target)
@@ -35,6 +28,7 @@ public class DarvAncientCardPatch
             }
         }
 
-        __instance.AncientCard = _customTome[player.Character];
+        if(_customTome.TryGetValue(player.Character, out var cardId))
+            __instance.AncientCard = cardId;
     }
 }


### PR DESCRIPTION
Dusty Tome, in its current state, has the issue of being terribly coded due to the fact that it just gets a random non-Orobas Ancient Card. This means if you make any Ancient card, it breaks. This is intended to fix that.

It makes it into a dictionary of CharacterModel and ModelId.
Also adds in an Interface for the Tome Card for modding it in.

Unsure if this would be "Content" or not but I just put it there since that's where the Transcendence patches were. 