### PR TITLE
Fix SimpleLoc pluralize regex to correctly reference the most recent variable

### DIFF
--- a/Patches/Localization/SimpleLoc.cs
+++ b/Patches/Localization/SimpleLoc.cs
@@ -59,7 +59,7 @@ public static partial class SimpleLoc
     [GeneratedRegex(@"(?:(?:-(.+?)-)|(?:\+(.+?)\+))(?:\+(.+?)\+)?")]
     private static partial Regex UpgradeSwapRegex { get; }
 
-    [GeneratedRegex(@"({)([^{]+?)((?::.*)?}.*?)\(([^()]+?)\)")]
+    [GeneratedRegex(@"(.*{)([^{]+?)((?::.*)?}.*?)\(([^()]+?)\)")]
     private static partial Regex PluralizeRegex { get; }
     
     [GeneratedRegex(@"\[(?:(E\?)|(E+))\]")]


### PR DESCRIPTION
The pluralize regex currently references the first variable, but it should reference the variable immediately preceding the plural text.