### PR TITLE
Fix placeholder multiplayer hands being invisible

### DIFF
--- a/Abstracts/PlaceholderCharacterModel.cs
+++ b/Abstracts/PlaceholderCharacterModel.cs
@@ -31,16 +31,16 @@ public abstract class PlaceholderCharacterModel : CustomCharacterModel
         SceneHelper.GetScenePath("merchant/characters/" + PlaceholderID + "_merchant");
 
     public override string CustomArmPointingTexturePath =>
-        ImageHelper.GetImagePath("ui/hands/" + PlaceholderID + "_arm_point.png");
+        ImageHelper.GetImagePath("ui/hands/multiplayer_hand_" + PlaceholderID + "_point.png");
 
     public override string CustomArmRockTexturePath =>
-        ImageHelper.GetImagePath("ui/hands/" + PlaceholderID + "_arm_rock.png");
+        ImageHelper.GetImagePath("ui/hands/multiplayer_hand_" + PlaceholderID + "_rock.png");
 
     public override string CustomArmPaperTexturePath =>
-        ImageHelper.GetImagePath("ui/hands/" + PlaceholderID + "_arm_paper.png");
+        ImageHelper.GetImagePath("ui/hands/multiplayer_hand_" + PlaceholderID + "_paper.png");
 
     public override string CustomArmScissorsTexturePath =>
-        ImageHelper.GetImagePath("ui/hands/" + PlaceholderID + "_arm_scissors.png");
+        ImageHelper.GetImagePath("ui/hands/multiplayer_hand_" + PlaceholderID + "_scissors.png");
 
     public override string CustomCharacterSelectBg =>
         SceneHelper.GetScenePath("screens/char_select/char_select_bg_" + PlaceholderID);


### PR DESCRIPTION
The default image paths for multiplayer hands in Treasure rooms were slightly incorrect and resulted in said hands being invisible until the mod author adds in their own overrides. This is my first ever pull request, so sorry if anything is done incorrectly!