### PR TITLE
fix SimpleLoc regexes

### DIFF
--- a/Patches/Localization/SimpleLoc.cs
+++ b/Patches/Localization/SimpleLoc.cs
@@ -50,10 +50,10 @@ public static partial class SimpleLoc
         }
     }
 
-    [GeneratedRegex(@"(^|[^/])\*(.+?)(?:\*|$|([\s\.|}]))")]
+    [GeneratedRegex(@"(?<=^|[^/])\*(.+?)(?=$|[\s*.,|}])\*?")]
     private static partial Regex GoldHighlightRegex { get; }
 
-    [GeneratedRegex(@"(^|[^/])\$(.+?)(?:\$|$|([\s\.|}]))")]
+    [GeneratedRegex(@"(?<=^|[^/])\$(.+?)(?=$|[\s$.,|}])\$?")]
     static partial Regex BlueHighlightRegex { get; }
 
     [GeneratedRegex(@"({)([^:}.]+)([:}])")] private static partial Regex NormalVariableRegex { get; }
@@ -63,7 +63,7 @@ public static partial class SimpleLoc
     [GeneratedRegex(@"(?:(?:-(.+?)-)|(?:\+(.+?)\+))(?:\+(.+?)\+)?")] 
     private static partial Regex UpgradeSwapRegex { get; }
 
-    [GeneratedRegex(@"(.*{)([^{]+?)((?::.*)?}.*?)\(([^()]+?)\)")]
+    [GeneratedRegex(@"(.*?{)([^{]+?)((?::[^{]*)?}[^{]*?)\(([^()]+?)\)")]
     private static partial Regex PluralizeRegex { get; }
     
     [GeneratedRegex(@"\[(?:(E\?)|(E+))\]")]
@@ -91,8 +91,8 @@ public static partial class SimpleLoc
     private static string Simplify(string loc)
     {
         if (loc.StartsWith('#')) return loc; //if loc starts with '##' remove first one and cancel simplify
-        loc = GoldHighlightRegex.Replace(loc, "$1[gold]$2[/gold]$3");
-        loc = BlueHighlightRegex.Replace(loc, "$1[blue]$2[/blue]$3");
+        loc = GoldHighlightRegex.Replace(loc, "[gold]$1[/gold]");
+        loc = BlueHighlightRegex.Replace(loc, "[blue]$1[/blue]");
         loc = loc.Replace("/*", "*").Replace("/$", "$");
         loc = NormalVariableRegex.Replace(loc, match => $"{match.Groups[1].Value}{SpecialVarDictionary.GetValueOrDefault(match.Groups[2].Value, match.Groups[2].Value)}{match.Groups[3].Value}");
         loc = DiffVariableRegex.Replace(loc, match => ReplaceVarName(match, ":diff()"));

--- a/Patches/Localization/SimpleLoc.cs
+++ b/Patches/Localization/SimpleLoc.cs
@@ -50,10 +50,10 @@ public static partial class SimpleLoc
         }
     }
 
-    [GeneratedRegex(@"(?<=^|[^/])\*(.+?)(?=$|[\s*.,|}])\*?")]
+    [GeneratedRegex(@"(?<=^|[^/])\*({.+?}|.+?(?=$|[\s*.,|}]))\*?")]
     private static partial Regex GoldHighlightRegex { get; }
 
-    [GeneratedRegex(@"(?<=^|[^/])\$(.+?)(?=$|[\s$.,|}])\$?")]
+    [GeneratedRegex(@"(?<=^|[^/])\$({.+?}|.+?(?=$|[\s$.,|}]))\$?")]
     static partial Regex BlueHighlightRegex { get; }
 
     [GeneratedRegex(@"({)([^:}.]+)([:}])")] private static partial Regex NormalVariableRegex { get; }


### PR DESCRIPTION
#### Highlighting regexes:
- Uses look-ahead and look-behind, so as not to consume surrounding chars. Currently, a second consecutive word wont match because it's leading space got consumed by the first match: "*First *Second".
- Will fully surround braces when the match starts on an opening brace: "${Amount}" (currently the match ends before the closing brace).
- Added comma as a delimiter.

#### Pluralize regex:
- Now matches all variable-plural pairs (not just the last one)