### PR TITLE
Clarify CustomReward error messages & logging

### DIFF
--- a/Patches/Content/CustomEnums.cs
+++ b/Patches/Content/CustomEnums.cs
@@ -326,6 +326,7 @@ class GenEnumValues
                 CustomPiles.RegisterCustomPile((PileType) pileType, () => (CustomPile) constructor.Invoke(null));
             }
 
+            // CustomReward Registration
             if (field.FieldType == typeof(RewardType) && t.IsAssignableTo(typeof(CustomReward)))
             {
                 if (t.CreateInstance() is not CustomReward dummyReward)

--- a/Patches/Content/CustomEnums.cs
+++ b/Patches/Content/CustomEnums.cs
@@ -334,19 +334,21 @@ class GenEnumValues
                     continue;
                 }
 
-                BaseLibMain.Logger.Debug($"Initializing CustomReward inheriting class {dummyReward.GetType()}");
+                BaseLibMain.Logger.Debug($"Validating {dummyReward.GetType()}'s ToSerializable method");
                 var serializable = dummyReward.ToSerializable();
                 if (serializable.RewardType == RewardType.None) // This will cause a crash if loading a saved reward screen with this reward in it
                 {
                     // This wants to be in the analyzer too, don't know how though
-                    throw new InvalidOperationException($"CustomReward {dummyReward.GetType()}'s RewardType is None or doesn't set RewardType");
+                    throw new InvalidOperationException(
+                        $"CustomReward {dummyReward.GetType()}'s RewardType is None, or doesn't set RewardType in it's ToSerializable override");
                 }
                 if (serializable.RewardType is >= RewardType.None and <= RewardType.SpecialCard)
                 {
                     //Using a basegame type would result in intercepting reward loading of basegame rewards which is unintended for CustomReward
                     throw new InvalidOperationException(
-                        $"$CustomReward {dummyReward.GetType()}'s RewardType is basegame type {serializable.RewardType} rather than a custom type");
+                        $"$CustomReward {dummyReward.GetType()}'s RewardType is vanilla type {serializable.RewardType} rather than a custom type");
                 }
+                BaseLibMain.Logger.Debug($"Initializing CustomReward inheriting class {dummyReward.GetType()}");
                 dummyReward.Initialize();
             }
         }

--- a/Patches/Content/CustomRewardPatches.cs
+++ b/Patches/Content/CustomRewardPatches.cs
@@ -16,11 +16,10 @@ internal static class CustomRewardPatches
     {
         if (_RewardTypeDeserializers.ContainsKey(type))
         {
-            BaseLibMain.Logger.Error($"Registering multiple rewards of the same type ({type}) is not supported");
             throw new NotSupportedException($"Registering multiple rewards of the same type ({type}) is not supported");
         }
 
-        BaseLibMain.Logger.Info($"Registering RewardType {nameof(type)}");
+        BaseLibMain.Logger.Info($"Registering RewardType {nameof(type)} from {deserializer.GetType().Assembly}");
         _RewardTypeDeserializers.Add(type, deserializer);
     }
 
@@ -30,7 +29,7 @@ internal static class CustomRewardPatches
     {
         if (_RewardTypeDeserializers.Keys.Contains(save.RewardType))
         {
-            BaseLibMain.Logger.Debug($"Found RewardType {save.RewardType} ({(int) save.RewardType}) in registry from mod {_RewardTypeDeserializers[save.RewardType].Method.GetType().Assembly}");
+            BaseLibMain.Logger.Debug($"Found RewardType {save.RewardType} ({(int) save.RewardType}) in registry from mod {_RewardTypeDeserializers[save.RewardType].GetType().Assembly}");
 
             var method = _RewardTypeDeserializers[save.RewardType];
             __result = method.Invoke(save, player);

--- a/Patches/Content/CustomRewardPatches.cs
+++ b/Patches/Content/CustomRewardPatches.cs
@@ -16,6 +16,7 @@ internal static class CustomRewardPatches
     {
         if (_RewardTypeDeserializers.ContainsKey(type))
         {
+            // Maybe just warn instead?
             throw new NotSupportedException($"Registering multiple rewards of the same type ({type}) is not supported");
         }
 


### PR DESCRIPTION
- Log assembly name when registering
- Specify that the `RewardType == None` check concerns the `CustomReward.ToSerializable()` override
- change "basegame" to "vanilla" (maybe an arbitrary change, both seem to be used interchangeably)