### PR TITLE
Add `TwoAmountPowers` utility for displaying secondary power amounts

### DIFF
--- a/Abstracts/IHasSecondAmount.cs
+++ b/Abstracts/IHasSecondAmount.cs
@@ -1,0 +1,23 @@
+﻿using BaseLib.Extensions;
+
+namespace BaseLib.Abstracts;
+
+/// <summary>
+/// Exposes a secondary display amount alongside the primary power amount.
+/// Implement this interface on any <c>PowerModel</c> that needs to show a
+/// second numeric or textual value in the UI (e.g. a counter or cooldown).
+/// </summary>
+/// <remarks>
+/// When the value changes, call <see cref="PowerExtensions.InvokeSecondAmountChanged"/>
+/// to trigger a UI refresh.
+/// </remarks>
+public interface IHasSecondAmount
+{
+    /// <summary>
+    /// Gets the secondary amount as a formatted string for UI display.
+    /// </summary>
+    /// <returns>
+    /// A string representing the secondary value.
+    /// </returns>
+    string GetSecondAmount();
+}

--- a/Extensions/PowerExtensions.cs
+++ b/Extensions/PowerExtensions.cs
@@ -25,6 +25,6 @@ public static class PowerExtensions
     public static void InvokeSecondAmountChanged(this IHasSecondAmount power)
     {
         if (SecondAmountRegistry.RefreshActions.TryGetValue(power, out var refresh))
-            refresh?.Invoke();
+            refresh();
     }
 }

--- a/Extensions/PowerExtensions.cs
+++ b/Extensions/PowerExtensions.cs
@@ -1,0 +1,30 @@
+﻿using BaseLib.Abstracts;
+using Baselib.Patches.Utils;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+
+namespace BaseLib.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="IHasSecondAmount"/> powers.
+/// Connects them to their <see cref="NPower"/> display node,
+/// allowing powers to trigger a label refresh without access to the node directly.
+/// </summary>
+public static class PowerExtensions
+{
+ 
+    /// <summary>
+    /// Triggers a UI refresh of the second amount label for this power.
+    /// Call this whenever the value returned by <see cref="IHasSecondAmount.GetSecondAmount"/> changes.
+    /// </summary>
+    /// <remarks>
+    /// Typical usage inside a power:
+    /// <code>
+    /// this.InvokeSecondAmountChanged();
+    /// </code>
+    /// </remarks>
+    public static void InvokeSecondAmountChanged(this IHasSecondAmount power)
+    {
+        if (SecondAmountRegistry.RefreshActions.TryGetValue(power, out var refresh))
+            refresh?.Invoke();
+    }
+}

--- a/Patches/Utils/TwoAmountPowers.cs
+++ b/Patches/Utils/TwoAmountPowers.cs
@@ -52,7 +52,7 @@ internal static class TwoAmountPowers
     private static void Subscribe(NPower __instance)
     {
         if (__instance._model is IHasSecondAmount power)
-            SecondAmountRegistry.Register(power, __instance.Reload);
+            SecondAmountRegistry.Register(power, __instance.RefreshAmount);
     }
 
     [HarmonyPatch(nameof(NPower.UnsubscribeFromModelEvents))]

--- a/Patches/Utils/TwoAmountPowers.cs
+++ b/Patches/Utils/TwoAmountPowers.cs
@@ -1,0 +1,78 @@
+﻿using System.Runtime.CompilerServices;
+using BaseLib.Abstracts;
+using Godot;
+using HarmonyLib;
+using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.Nodes.Combat;
+
+namespace Baselib.Patches.Utils;
+
+/**
+ * Credits to kiooeht, this displays a second amount for powers that require tracking multiple values.
+ * https://github.com/erasels/Minty-Spire-2/blob/main/src/combat/TwoAmountPowers.cs
+ */
+[HarmonyPatch(typeof(NPower))]
+internal static class TwoAmountPowers
+{
+    [HarmonyPatch("RefreshAmount")]
+    [HarmonyPostfix]
+    private static void ShowSecondAmount(NPower __instance)
+    {
+        if (!__instance.IsNodeReady()) return;
+        if (__instance._model is not IHasSecondAmount power) return;
+
+        if (!__instance.HasNode("Amount2Label"))
+        {
+            var label = __instance.GetNode<MegaLabel>("%AmountLabel");
+            var newLabel = (MegaLabel)label.Duplicate();
+            newLabel.Name = "Amount2Label";
+            newLabel.UniqueNameInOwner = false;
+            newLabel.Visible = false;
+            __instance.AddChild(newLabel);
+            __instance.MoveChild(newLabel, label.GetIndex());
+        }
+
+        var amount1Label = __instance.GetNode<MegaLabel>("%AmountLabel");
+        var amount2Label = __instance.GetNode<MegaLabel>("Amount2Label");
+        var text = power.GetSecondAmount();
+
+        if (string.IsNullOrEmpty(text))
+        {
+            amount2Label.Visible = false;
+            return;
+        }
+
+        amount2Label.Visible = true;
+        amount2Label.SetTextAutoSize(text);
+        var fontSize = amount2Label.GetThemeFontSize(ThemeConstants.Label.FontSize);
+        amount2Label.Position = amount1Label.Position + new Vector2(0, -(fontSize + 2));
+    }
+    [HarmonyPatch(nameof(NPower.SubscribeToModelEvents))]
+    [HarmonyPostfix]
+    private static void Subscribe(NPower __instance)
+    {
+        if (__instance._model is IHasSecondAmount power)
+            SecondAmountRegistry.Register(power, __instance.Reload);
+    }
+
+    [HarmonyPatch(nameof(NPower.UnsubscribeFromModelEvents))]
+    [HarmonyPostfix]
+    private static void Unsubscribe(NPower __instance)
+    {
+        if (__instance._model is IHasSecondAmount power)
+            SecondAmountRegistry.Unregister(power);
+    }
+}
+
+internal static class SecondAmountRegistry
+{
+    internal static readonly ConditionalWeakTable<IHasSecondAmount, Action> RefreshActions = new();
+
+    internal static void Register(IHasSecondAmount power, Action refresh)
+        => RefreshActions.AddOrUpdate(power, refresh);
+
+    internal static void Unregister(IHasSecondAmount power)
+        => RefreshActions.Remove(power);
+}
+
+


### PR DESCRIPTION
I actually dont know what is planned or already there for two amount powers by others.
But this is my simple Second Power Amount Display

Implementing it is very simple. Just implement the IHasSecondAmount interface and use the GetSecondAmount() method, updating it with the InvokeSecondAmountChanged method when necessary.
```cs

public class MyPower: MyAbstractPower, IHasSecondAmount
{

  // ...
  
  public override async Task AfterCardPlayed(PlayerChoiceContext ctx, CardPlay cardPlay)
  {
      if (cardPlay.Card.Owner.Creature != Owner || cardPlay.Card.Type != CardType.Attack) return;
      DynamicVars["AttacksPlayed"].UpgradeValueBy(1);
      this.InvokeSecondAmountChanged();
  }
      
  public string GetSecondAmount() => $"{DynamicVars["AttacksPlayed"].IntValue}";

}
```