### PR TITLE
Added Custom Loc Table API

### DIFF
--- a/Patches/Localization/CustomLocTablePatches.cs
+++ b/Patches/Localization/CustomLocTablePatches.cs
@@ -1,0 +1,45 @@
+﻿/* CustomLocTablePatches.cs
+ * Authors: Pikcube, lamali
+ * Date Last Modified: 2026-05-18
+ * Description: Patches the LocManager to add any loc tables registered in in CustomLocTableManager
+ *
+ * Usages:
+ * CustomLocManager.Register("mytable.json");
+ * LocManager.Instance.Register("mytable.json");
+ */
+
+using BaseLib.Utils;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Localization;
+using FileAccess = Godot.FileAccess;
+
+namespace BaseLib.Patches.Localization;
+
+internal static class CustomLocTablePatches
+{
+    [HarmonyPatch(typeof(LocManager), "ListLocalizationFiles")]
+    internal static class ListLocalizationFilesPatch
+    {
+        //Append any additional loc tbales to the list of localization files.
+        public static IEnumerable<string> Postfix(IEnumerable<string> __result)
+        {
+            return CustomLocTableManager.GetCustomLocTables(__result);
+        }
+    }
+
+    [HarmonyPatch(typeof(LocManager), "LoadTable")]
+    internal static class LoadTablePatch
+    {
+        //Prevents the game from throwing an error when trying to load a localization file not present in the base game by force returning an empty dictionary if the file isn't found.
+        public static bool Prefix(string path, ref Dictionary<string, string> __result)
+        {
+            if (FileAccess.FileExists(path))
+            {
+                return true;
+            }
+
+            __result = [];
+            return false;
+        }
+    }
+}

--- a/Utils/CustomLocTableManager.cs
+++ b/Utils/CustomLocTableManager.cs
@@ -1,0 +1,52 @@
+﻿/* CustomLocTableManager.cs
+ * Authors: Pikcube
+ * Date Last Modified: 2026-05-18
+ * Description: Adds a public facing static class for registering custom loc tables
+ *
+ * Usages:
+ * CustomLocManager.Register("mytable.json");
+ * LocManager.Instance.Register("mytable.json");
+ */
+
+using MegaCrit.Sts2.Core.Localization;
+
+namespace BaseLib.Utils;
+
+/// <summary>
+/// Static class for tracking Loc Tables added by other mods
+/// </summary>
+public static class CustomLocTableManager
+{
+    private static readonly HashSet<string> LocTables = [];
+    /// <summary>
+    /// Append any registered LocTables to the list of custom loc tables.
+    /// </summary>
+    /// <param name="original">The original list of Localization Files</param>
+    /// <returns>The original list with this.LocTables appended to the end.</returns>
+    internal static IEnumerable<string> GetCustomLocTables(IEnumerable<string> original)
+    {
+        return [.. original, .. LocTables];
+    }
+
+    /// <summary>
+    /// Add a custom loc table to the game.
+    /// </summary>
+    /// <param name="name">The name of the json file to register.</param>
+    public static void Register(string name)
+    {
+        if (!name.EndsWith(".json"))
+        {
+            name += ".json";
+        }
+
+        LocTables.Add(name);
+    }
+
+    /// <summary>
+    /// Adds a custom loc table to the game using BaseLib.Utils.CustomLocTableManager.<br/>
+    /// Equivalent to CustomLocTableManager.Register(name);
+    /// </summary>
+    /// <param name="locManager">The current loc manager.</param>
+    /// <param name="name">The name of the json file to register.</param>
+    public static void RegisterCustomLocTable(this LocManager locManager, string name) => Register(name);     //This is just an alais I added to try and make this more discoverable for people using intellisense.
+}


### PR DESCRIPTION
Adds an API for registering custom Localization Files.

Adding new localization files currently requires patching the LocManager to include any additional localization files, along with making sure the base game doesn't crash when trying to load a localization file that only exists within mods.

To handle this, I have added a simple `CustomLocTableManager` class, which allows developers to register their custom loc tables in their mod initializer function.

The register function is idempotent, so multiple players trying to register the same loc table will not present any issues as long as they are prefixing their keys appropriately.

I added an extension to LocManager to try and help with discoverability. Despite the fact that LocManager.Instance is not initialized when mod initializers are called, calling an extension method will not throw an exception since they are transformed into static method calls by the compiler.