### PR TITLE
fix check when purging cards to ensure its DeckVersion is still in the deck

### DIFF
--- a/Patches/Hooks/AfterCardPlayedPatch.cs
+++ b/Patches/Hooks/AfterCardPlayedPatch.cs
@@ -33,7 +33,7 @@ class AfterCardPlayedPatch
             if (PurgePatch.ShouldPurge(cardPlay.Card))
             {
                 var deckCard = cardPlay.Card.DeckVersion;
-                if (deckCard != null)
+                if (deckCard?.Pile?.Type == PileType.Deck) // Guard against Replay (first play sets Pile to null)
                 {
                     await CardPileCmd.RemoveFromDeck(deckCard, false);
                 }


### PR DESCRIPTION
Guards against Replay, where the first play sets Pile to null