### PR TITLE
Add CustomTemporaryPowerModelWrapper support for various missing Model types

### DIFF
--- a/Abstracts/CustomTemporaryPowerModelWrapper.cs
+++ b/Abstracts/CustomTemporaryPowerModelWrapper.cs
@@ -57,6 +57,10 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     return monsterModel.Title;
                 case ActModel actModel:
                     return actModel.Title;
+                case EnchantmentModel enchantmentModel:
+                    return enchantmentModel.Title;
+                case AfflictionModel afflictionModel:
+                    return afflictionModel.Title;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the 'Title' for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet. Using default title.");
                     return new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
@@ -85,6 +89,20 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     break;
                 case ActModel:
                     items = [];
+                    break;
+                case EnchantmentModel:
+                    var enchantmentModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as EnchantmentModel)?.ToMutable();
+                    if (enchantmentModel is not null)
+                    {
+                        enchantmentModel.Amount = Amount;
+                        enchantmentModel.RecalculateValues();
+                    }
+                    items = enchantmentModel?.HoverTips.ToList() ?? [];
+                    break;
+                case AfflictionModel:
+                    var afflictionModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as AfflictionModel)?.ToMutable();
+                    afflictionModel?.Amount = Amount;
+                    items = afflictionModel?.HoverTips.ToList() ?? [];
                     break;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the Hover Tips for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet.");

--- a/Abstracts/CustomTemporaryPowerModelWrapper.cs
+++ b/Abstracts/CustomTemporaryPowerModelWrapper.cs
@@ -61,6 +61,14 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     return enchantmentModel.Title;
                 case AfflictionModel afflictionModel:
                     return afflictionModel.Title;
+                case EncounterModel encounterModel:
+                    return encounterModel.Title;
+                case EventModel eventModel:
+                    return eventModel.Title;
+                case ModifierModel modifierModel:
+                    return modifierModel.Title;
+                case CardModifier cardModifier:
+                    return cardModifier.Owner?.TitleLocString ?? new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
                 default:
                     BaseLibMain.Logger.Warn($"Getting the 'Title' for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet. Using default title.");
                     return new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
@@ -88,21 +96,26 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     items = [HoverTipFactory.FromPower(power)];
                     break;
                 case ActModel:
+                case EncounterModel:
+                case EventModel:
                     items = [];
                     break;
-                case EnchantmentModel:
-                    var enchantmentModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as EnchantmentModel)?.ToMutable();
-                    if (enchantmentModel is not null)
-                    {
-                        enchantmentModel.Amount = Amount;
-                        enchantmentModel.RecalculateValues();
-                    }
-                    items = enchantmentModel?.HoverTips.ToList() ?? [];
+                case EnchantmentModel enchantmentModel:
+                    var enchantmentModelClone = (EnchantmentModel)enchantmentModel.MutableClone();
+                    enchantmentModelClone.Amount = Amount;
+                    enchantmentModelClone.RecalculateValues();
+                    items = enchantmentModelClone.HoverTips.ToList();
                     break;
-                case AfflictionModel:
-                    var afflictionModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as AfflictionModel)?.ToMutable();
-                    afflictionModel?.Amount = Amount;
-                    items = afflictionModel?.HoverTips.ToList() ?? [];
+                case AfflictionModel afflictionModel:
+                    var afflictionModelClone = (AfflictionModel)afflictionModel.MutableClone();
+                    afflictionModelClone.Amount = Amount;
+                    items = afflictionModelClone.HoverTips.ToList();
+                    break;
+                case ModifierModel modifierModel:
+                    items = modifierModel.HoverTips.ToList();
+                    break;
+                case CardModifier cardModifier:
+                    items = cardModifier.Owner != null ? [HoverTipFactory.FromCard(cardModifier.Owner)] : [];
                     break;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the Hover Tips for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet.");


### PR DESCRIPTION
New supported models:

- EnchantmentModel
- AfflictionModel
- EncounterModel
- EventModel
- ModifierModel
- CardModifier

This now covers any model that could realistically apply a temporary power during combat.
Remaining unsupported models are:
`AbstractModel`, `AchievementModel`, `BadgeModel`, `CardPoolModel`, `PotionPoolModel`, `RelicPoolModel`, `SingletonModel`
`AncientEventModel` inherits from `EventModel`


BaseLibs `CardModifier` will for now use the card it is attached to as fallback for `Title` and `HoverTips`.

Enchantments and Afflictions will create a mutable clone to get the hovertip from so the Amount can be modified to reflect the total Amount if multiple power applications happen.
Technically it could modify the value for `EnchantmentModel` directly since the property is a direct `get set` to `_amount`, but cloning it prevents potential weird interactions when someone listens to a change in Amount through a patch.