### PR TITLE
CustomPool SeenByDefault

### DIFF
--- a/Abstracts/CustomCardPoolModel.cs
+++ b/Abstracts/CustomCardPoolModel.cs
@@ -4,6 +4,8 @@ using BaseLib.Utils;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Screens.CardLibrary;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -66,6 +68,23 @@ public abstract class CustomCardPoolModel : CardPoolModel, ICustomModel, ICustom
     /// </summary>
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all cards in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NCardLibraryGrid), "RefreshVisibility")]
+static class CustomCardPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var cardPool in ModelDb.AllCardPools)
+            if (cardPool is CustomCardPoolModel customCardPool && customCardPool.SeenByDefault)
+                foreach (var card in cardPool.AllCards) SaveManager.Instance.MarkCardAsSeen(card);
+    }
 }
 
 [HarmonyPatch(typeof(CardPoolModel), "FrameMaterial", MethodType.Getter)]

--- a/Abstracts/CustomPotionPoolModel.cs
+++ b/Abstracts/CustomPotionPoolModel.cs
@@ -1,6 +1,9 @@
 using MegaCrit.Sts2.Core.Models;
 using BaseLib.Patches.Content;
 using BaseLib.Patches.UI;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.PotionLab;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -21,4 +24,21 @@ public abstract class CustomPotionPoolModel : PotionPoolModel, ICustomModel, ICu
     public override string EnergyColorName => CustomEnergyIconPatches.GetEnergyColorName(Id);
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all potions in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NPotionLab), "LoadPotions")]
+static class CustomPotionPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var potionPool in ModelDb.AllPotionPools)
+            if (potionPool is CustomPotionPoolModel customPotionPool && customPotionPool.SeenByDefault)
+                foreach (var potion in potionPool.AllPotions) SaveManager.Instance.MarkPotionAsSeen(potion);
+    }
 }

--- a/Abstracts/CustomRelicPoolModel.cs
+++ b/Abstracts/CustomRelicPoolModel.cs
@@ -1,6 +1,9 @@
 using MegaCrit.Sts2.Core.Models;
 using BaseLib.Patches.Content;
 using BaseLib.Patches.UI;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.RelicCollection;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -21,4 +24,21 @@ public abstract class CustomRelicPoolModel : RelicPoolModel, ICustomModel, ICust
     public override string EnergyColorName => CustomEnergyIconPatches.GetEnergyColorName(Id);
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all relics in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NRelicCollection), "LoadRelics")]
+static class CustomRelicPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var relicPool in ModelDb.AllRelicPools)
+            if (relicPool is CustomRelicPoolModel customRelicPool && customRelicPool.SeenByDefault)
+                foreach (var relic in relicPool.AllRelics) SaveManager.Instance.MarkRelicAsSeen(relic);
+    }
 }


### PR DESCRIPTION
adds a property to card, relic, and potion pools that can be overridden to true to automatically mark all their items as seen in the compendium (like BaseMod's `AutoAdd.setDefaultSeen()`)

(should this be true by default? or should the mod template set this to true)