### PR TITLE
3.1.9

### DIFF
--- a/Abstracts/CardModifier.cs
+++ b/Abstracts/CardModifier.cs
@@ -19,10 +19,10 @@ namespace BaseLib.Abstracts;
 /// Receives all combat hooks, and is capable of modifying the card's description.
 /// More features to be added in the future.
 /// </summary>
-public abstract class CardModifier : AbstractModel
+public abstract class CardModifier : AbstractModel, IComparable<CardModifier>
 {
     /// <summary>
-    /// Obtains a new instance of a CardModifier from ModelDb using <see cref="ModelDbExtensions.CardModifier"/>
+    /// Obtains a new instance of a CardModifier from ModelDb using <see cref="ModelDbExtensions.CardModifier"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
@@ -231,7 +231,7 @@ public abstract class CardModifier : AbstractModel
     
     private void ApplyInternal(CardModel card)
     {
-        DirectModifiers(card).Add(this);
+        DirectModifiers(card).InsertSorted(this);
         Owner = card;
         OnInitialApplication();
     }
@@ -242,6 +242,12 @@ public abstract class CardModifier : AbstractModel
             Owner = null;
         return DirectModifiers(card).Remove(this);
     }
+
+    /// <summary>
+    /// Affects the ordering of card modifiers when they are added to a card.
+    /// Lower priority means the card modifier will be inserted before card modifiers of higher priority.
+    /// </summary>
+    public int Priority { get; set; } = 0;
 
     /// <summary>
     /// Modifies a card's description before the game processes it.
@@ -285,6 +291,11 @@ public abstract class CardModifier : AbstractModel
     public virtual Task OnPlay(PlayerChoiceContext choiceContext, CardPlay cardPlay)
     {
         return Task.CompletedTask;
+    }
+
+    int IComparable<CardModifier>.CompareTo(CardModifier? other)
+    {
+        return Priority.CompareTo(other?.Priority ?? 0);
     }
 }
 

--- a/Abstracts/CardModifier.cs
+++ b/Abstracts/CardModifier.cs
@@ -21,6 +21,16 @@ namespace BaseLib.Abstracts;
 /// </summary>
 public abstract class CardModifier : AbstractModel
 {
+    /// <summary>
+    /// Obtains a new instance of a CardModifier from ModelDb using <see cref="ModelDbExtensions.CardModifier"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public static T Get<T>() where T : CardModifier
+    {
+        return ModelDb.CardModifier<T>();
+    }
+    
     public static void RegisterSave()
     {
         ExtendedSaveTypes.RegisterListSaveType<ModifierSave>();

--- a/Abstracts/CardModifier.cs
+++ b/Abstracts/CardModifier.cs
@@ -4,7 +4,9 @@ using BaseLib.Patches.Localization;
 using BaseLib.Patches.Saves;
 using BaseLib.Utils;
 using HarmonyLib;
+using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
 using MegaCrit.Sts2.Core.Modding;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.Multiplayer.Serialization;
@@ -161,17 +163,14 @@ public abstract class CardModifier : AbstractModel
     /// </summary>
     public static void AddModifier(CardModel card, CardModifier modifier)
     {
-        DirectModifiers(card).Add(modifier);
-        modifier.Owner = card;
+        modifier.ApplyInternal(card);
     }
 
     public static bool RemoveModifier(CardModel card, CardModifier modifier)
     {
-        if (modifier.Owner == card)
-            modifier.Owner = null;
-        return DirectModifiers(card).Remove(modifier);
+        return modifier.RemoveInternal(card);
     }
-    
+
     static CardModifier()
     {
         ModHelper.SubscribeForCombatStateHooks("BaseLibCardModifiers",
@@ -219,6 +218,20 @@ public abstract class CardModifier : AbstractModel
         get; 
         private set;
     }
+    
+    private void ApplyInternal(CardModel card)
+    {
+        DirectModifiers(card).Add(this);
+        Owner = card;
+        OnInitialApplication();
+    }
+
+    private bool RemoveInternal(CardModel card)
+    {
+        if (Owner == card)
+            Owner = null;
+        return DirectModifiers(card).Remove(this);
+    }
 
     /// <summary>
     /// Modifies a card's description before the game processes it.
@@ -239,11 +252,29 @@ public abstract class CardModifier : AbstractModel
     }
 
     /// <summary>
+    /// Called after the modifier is applied to a card, including when a card is copied.
+    /// Due to nature of when this occurs, async combat effects should not occur here.
+    /// </summary>
+    public virtual void OnInitialApplication()
+    {
+        
+    }
+
+    /// <summary>
     /// Called after the card modifier is cloned and added to a clone of a card.
+    /// Called whenever a MutableClone is created.
     /// </summary>
     public virtual void AfterClonedOnCard(CardModel card)
     {
         
+    }
+    
+    /// <summary>
+    /// Called after the card's OnPlay method is called. Occurs before normal AfterCardPlayed hook.
+    /// </summary>
+    public virtual Task OnPlay(PlayerChoiceContext choiceContext, CardPlay cardPlay)
+    {
+        return Task.CompletedTask;
     }
 }
 

--- a/Abstracts/CustomCardPoolModel.cs
+++ b/Abstracts/CustomCardPoolModel.cs
@@ -4,6 +4,8 @@ using BaseLib.Utils;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Screens.CardLibrary;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -66,6 +68,23 @@ public abstract class CustomCardPoolModel : CardPoolModel, ICustomModel, ICustom
     /// </summary>
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all cards in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NCardLibraryGrid), "RefreshVisibility")]
+static class CustomCardPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var cardPool in ModelDb.AllCardPools)
+            if (cardPool is CustomCardPoolModel customCardPool && customCardPool.SeenByDefault)
+                foreach (var card in cardPool.AllCards) SaveManager.Instance.MarkCardAsSeen(card);
+    }
 }
 
 [HarmonyPatch(typeof(CardPoolModel), "FrameMaterial", MethodType.Getter)]

--- a/Abstracts/CustomMonsterModel.cs
+++ b/Abstracts/CustomMonsterModel.cs
@@ -1,4 +1,5 @@
 ﻿using BaseLib.Extensions;
+using BaseLib.Patches.Content;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Animation;
 using MegaCrit.Sts2.Core.Bindings.MegaSpine;
@@ -9,6 +10,11 @@ namespace BaseLib.Abstracts;
 
 public abstract class CustomMonsterModel : MonsterModel, ICustomModel, ISceneConversions
 {
+    public CustomMonsterModel()
+    {
+        CustomContentDictionary.RegisterType(GetType());
+    }
+    
     /// <summary>
     /// Override this or place your scene at res://scenes/creature_visuals/modname-class_name.tscn
     /// </summary>

--- a/Abstracts/CustomPotionPoolModel.cs
+++ b/Abstracts/CustomPotionPoolModel.cs
@@ -1,6 +1,9 @@
 using MegaCrit.Sts2.Core.Models;
 using BaseLib.Patches.Content;
 using BaseLib.Patches.UI;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.PotionLab;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -21,4 +24,21 @@ public abstract class CustomPotionPoolModel : PotionPoolModel, ICustomModel, ICu
     public override string EnergyColorName => CustomEnergyIconPatches.GetEnergyColorName(Id);
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all potions in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NPotionLab), "LoadPotions")]
+static class CustomPotionPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var potionPool in ModelDb.AllPotionPools)
+            if (potionPool is CustomPotionPoolModel customPotionPool && customPotionPool.SeenByDefault)
+                foreach (var potion in potionPool.AllPotions) SaveManager.Instance.MarkPotionAsSeen(potion);
+    }
 }

--- a/Abstracts/CustomRelicPoolModel.cs
+++ b/Abstracts/CustomRelicPoolModel.cs
@@ -1,6 +1,9 @@
 using MegaCrit.Sts2.Core.Models;
 using BaseLib.Patches.Content;
 using BaseLib.Patches.UI;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes.Screens.RelicCollection;
+using MegaCrit.Sts2.Core.Saves;
 
 namespace BaseLib.Abstracts;
 
@@ -21,4 +24,21 @@ public abstract class CustomRelicPoolModel : RelicPoolModel, ICustomModel, ICust
     public override string EnergyColorName => CustomEnergyIconPatches.GetEnergyColorName(Id);
     public virtual string? BigEnergyIconPath => null;
     public virtual string? TextEnergyIconPath => null;
+
+    /// <summary>
+    /// Override to true if all relics in this pool should automatically be marked as seen in the compendium
+    /// </summary>
+    public virtual bool SeenByDefault => false;
+}
+
+[HarmonyPatch(typeof(NRelicCollection), "LoadRelics")]
+static class CustomRelicPoolMarkAsSeenPatch
+{
+    [HarmonyPrefix]
+    public static void MarkAllAsSeen()
+    {
+        foreach (var relicPool in ModelDb.AllRelicPools)
+            if (relicPool is CustomRelicPoolModel customRelicPool && customRelicPool.SeenByDefault)
+                foreach (var relic in relicPool.AllRelics) SaveManager.Instance.MarkRelicAsSeen(relic);
+    }
 }

--- a/Abstracts/CustomTemporaryPowerModel.cs
+++ b/Abstracts/CustomTemporaryPowerModel.cs
@@ -142,7 +142,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
 
     public override async Task AfterSideTurnEnd(PlayerChoiceContext choiceContext, CombatSide side, IEnumerable<Creature> participants)
     {
-        if (!participants.Contains(Owner))
+        if (participants.Contains(Owner) == UntilEndOfOtherSideTurn)
             return;
         
         if (InternallyAppliedPower is CustomTemporaryPowerModel)
@@ -150,9 +150,7 @@ public abstract class CustomTemporaryPowerModel : CustomPowerModel, ITemporaryPo
             await PowerCmd.Remove(this);
             return;
         }
-        
-        if ((!UntilEndOfOtherSideTurn && side != Owner.Side) || (UntilEndOfOtherSideTurn && side == Owner.Side))
-            return;
+
         if (DynamicVars.Repeat.BaseValue > 0)
         {
             DynamicVars.Repeat.UpgradeValueBy(-1);

--- a/Abstracts/CustomTemporaryPowerModelWrapper.cs
+++ b/Abstracts/CustomTemporaryPowerModelWrapper.cs
@@ -57,6 +57,10 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     return monsterModel.Title;
                 case ActModel actModel:
                     return actModel.Title;
+                case EnchantmentModel enchantmentModel:
+                    return enchantmentModel.Title;
+                case AfflictionModel afflictionModel:
+                    return afflictionModel.Title;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the 'Title' for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet. Using default title.");
                     return new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
@@ -85,6 +89,20 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     break;
                 case ActModel:
                     items = [];
+                    break;
+                case EnchantmentModel:
+                    var enchantmentModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as EnchantmentModel)?.ToMutable();
+                    if (enchantmentModel is not null)
+                    {
+                        enchantmentModel.Amount = Amount;
+                        enchantmentModel.RecalculateValues();
+                    }
+                    items = enchantmentModel?.HoverTips.ToList() ?? [];
+                    break;
+                case AfflictionModel:
+                    var afflictionModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as AfflictionModel)?.ToMutable();
+                    afflictionModel?.Amount = Amount;
+                    items = afflictionModel?.HoverTips.ToList() ?? [];
                     break;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the Hover Tips for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet.");

--- a/Abstracts/CustomTemporaryPowerModelWrapper.cs
+++ b/Abstracts/CustomTemporaryPowerModelWrapper.cs
@@ -61,6 +61,14 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     return enchantmentModel.Title;
                 case AfflictionModel afflictionModel:
                     return afflictionModel.Title;
+                case EncounterModel encounterModel:
+                    return encounterModel.Title;
+                case EventModel eventModel:
+                    return eventModel.Title;
+                case ModifierModel modifierModel:
+                    return modifierModel.Title;
+                case CardModifier cardModifier:
+                    return cardModifier.Owner?.TitleLocString ?? new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
                 default:
                     BaseLibMain.Logger.Warn($"Getting the 'Title' for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet. Using default title.");
                     return new LocString("powers",  "BASELIB-CUSTOM_TEMPORARY_POWER_MODEL.title");
@@ -88,21 +96,26 @@ public abstract class CustomTemporaryPowerModelWrapper<TModel, TPower> : CustomT
                     items = [HoverTipFactory.FromPower(power)];
                     break;
                 case ActModel:
+                case EncounterModel:
+                case EventModel:
                     items = [];
                     break;
-                case EnchantmentModel:
-                    var enchantmentModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as EnchantmentModel)?.ToMutable();
-                    if (enchantmentModel is not null)
-                    {
-                        enchantmentModel.Amount = Amount;
-                        enchantmentModel.RecalculateValues();
-                    }
-                    items = enchantmentModel?.HoverTips.ToList() ?? [];
+                case EnchantmentModel enchantmentModel:
+                    var enchantmentModelClone = (EnchantmentModel)enchantmentModel.MutableClone();
+                    enchantmentModelClone.Amount = Amount;
+                    enchantmentModelClone.RecalculateValues();
+                    items = enchantmentModelClone.HoverTips.ToList();
                     break;
-                case AfflictionModel:
-                    var afflictionModel = (ModelDb.GetById<AbstractModel>(ModelDb.GetId<TModel>()) as AfflictionModel)?.ToMutable();
-                    afflictionModel?.Amount = Amount;
-                    items = afflictionModel?.HoverTips.ToList() ?? [];
+                case AfflictionModel afflictionModel:
+                    var afflictionModelClone = (AfflictionModel)afflictionModel.MutableClone();
+                    afflictionModelClone.Amount = Amount;
+                    items = afflictionModelClone.HoverTips.ToList();
+                    break;
+                case ModifierModel modifierModel:
+                    items = modifierModel.HoverTips.ToList();
+                    break;
+                case CardModifier cardModifier:
+                    items = cardModifier.Owner != null ? [HoverTipFactory.FromCard(cardModifier.Owner)] : [];
                     break;
                 default:
                     BaseLibMain.Logger.Warn($"Getting the Hover Tips for the base model type of '{OriginModel.GetType().Name}' has not been implemented yet.");

--- a/BaseLib.csproj
+++ b/BaseLib.csproj
@@ -21,9 +21,9 @@
         <PackageId>Alchyr.Sts2.BaseLib</PackageId>
         <Title>BaseLib-StS2</Title>
         <Description>Mod for Slay the Spire 2 providing utilities and features for other mods.</Description>
-        <Version>3.1.8</Version>
+        <Version>3.1.9</Version>
         <Authors>Alchyr</Authors>
-        <PackageReleaseNotes>Main branch compatibility</PackageReleaseNotes>
+        <PackageReleaseNotes>Rewrite AsyncMethodCall to fix some issues, small additions to CardModifier, MoveBuilder, temp power fixes, uid/user path support for some methods, SeenByDefault on pools, fix scene conversion registration for CustomMonsterModel</PackageReleaseNotes>
         <PackageTags>c#</PackageTags>
         <NoWarn>$(NoWarn);NU5128;MSB3270</NoWarn>
 
@@ -72,7 +72,7 @@
         <None Include="Notes.txt" />
         <None Include="export_presets.cfg" />
         <None Include="BaseLib.json" />
-        <None Include="Publish/*" />
+        <None Include="Publish/**/*" />
         <None Include="**/*.gd" />
     </ItemGroup>
 

--- a/BaseLib.json
+++ b/BaseLib.json
@@ -3,7 +3,7 @@
   "name": "BaseLib",
   "author": "Alchyr",
   "description": "Modding utility for Slay the Spire 2",
-  "version": "v3.1.8",
+  "version": "v3.1.9",
   "has_pck": true,
   "has_dll": true,
   "dependencies": [],

--- a/Extensions/IEnumerableExtensions.cs
+++ b/Extensions/IEnumerableExtensions.cs
@@ -27,6 +27,12 @@ public static class IEnumerableExtensions
         return sb.ToString();
     }
 
+    internal static T LogCode<T>(this T code) where T : IEnumerable<CodeInstruction>
+    {
+        BaseLibMain.Logger.Info($"CODE:\n{code.Join(instruction => instruction.ToString(), "\n")}");
+        return code;
+    }
+
     public static void CheckCode(this IEnumerable<CodeInstruction> code)
     {
         //Check for duplicate or missing labels

--- a/Extensions/IEnumerableExtensions.cs
+++ b/Extensions/IEnumerableExtensions.cs
@@ -1,5 +1,7 @@
 using System.Collections;
+using System.Reflection.Emit;
 using System.Text;
+using HarmonyLib;
 
 namespace BaseLib.Extensions;
 
@@ -23,5 +25,78 @@ public static class IEnumerableExtensions
             ++line;
         }
         return sb.ToString();
+    }
+
+    public static void CheckCode(this IEnumerable<CodeInstruction> code)
+    {
+        //Check for duplicate or missing labels
+        var codeList = code.ToList();
+        HashSet<Label> allLabels = [];
+        HashSet<Label> jumpDestinations = [];
+        for (var index = 0; index < codeList.Count; index++)
+        {
+            var ci = codeList[index];
+            
+            foreach (var label in ci.labels)
+            {
+                if (!allLabels.Add(label))
+                {
+                    BaseLibMain.Logger.Warn($"DUPLICATE LABEL: {label.Id}");
+                }
+            }
+
+            if (ci.Branches(out var dest))
+            {
+                if (dest == null)
+                {
+                    BaseLibMain.Logger.Warn($"Branch operation missing operand at index {index}");
+                }
+                else
+                {
+                    if (!jumpDestinations.Add(dest.Value))
+                    {
+                        BaseLibMain.Logger.Warn($"Minor: Label {dest.Value.Id} is reused");
+                    }
+                }
+            }
+            else if (ci.opcode == OpCodes.Switch)
+            {
+                if (ci.operand is Label[] labels)
+                {
+                    foreach (var label in labels)
+                    {
+                        if (!jumpDestinations.Add(label))
+                        {
+                            BaseLibMain.Logger.Warn($"Minor: Label {label.Id} is reused");
+                        }
+                    }
+                }
+            }
+            else if (ci.opcode == OpCodes.Leave || ci.opcode == OpCodes.Leave_S)
+            {
+                if (ci.operand is Label label)
+                {
+                    if (!jumpDestinations.Add(label))
+                    {
+                        BaseLibMain.Logger.Warn($"Minor: Label {label.Id} is reused");
+                    }
+                }
+                else
+                {
+                    BaseLibMain.Logger.Warn($"Leave operation missing label operand at index {index}");
+                }
+            }
+        }
+
+        if (jumpDestinations.Count > allLabels.Count)
+        {
+            jumpDestinations.RemoveWhere(allLabels.Contains);
+            BaseLibMain.Logger.Warn($"Jump destinations not found: {jumpDestinations.Join(label => label.Id.ToString())}");
+        }
+        else if (allLabels.Count > jumpDestinations.Count)
+        {
+            allLabels.RemoveWhere(jumpDestinations.Contains);
+            BaseLibMain.Logger.Warn($"Unused labels: {allLabels.Join(label => label.Id.ToString())}");
+        }
     }
 }

--- a/Extensions/ImageHelperExtensions.cs
+++ b/Extensions/ImageHelperExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using MegaCrit.Sts2.Core.Helpers;
 
 namespace BaseLib.Extensions;
 
@@ -7,30 +8,29 @@ namespace BaseLib.Extensions;
 /// </summary>
 public static class ImageHelperExtensions
 {
-    // TODO: Bug alch about switching to c# 14 and .NET-10 for baselib dev
-    // would be nice to use the extension(ImageHelper imageHelper) syntax and define static methods
-
-    /// <summary>
-    /// Tries to get the image for a given path, including the mod name.\n
-    /// Note that if given the <paramref name="type"/> parameter, this will return the root
-    /// namespace for that type (<c>BaseLib</c> in the case of this mod),
-    /// whereas it will return the assembly name of the calling method if not provided.
-    /// Both of these can differ from the actual path you used if you changed the
-    /// mod's name, or the filepath differs from the one created by the templates
-    /// </summary>
-    /// <param name="innerPath">The path of the .png or otherwise file, without the ModName/images/ section</param>
-    /// <param name="type">Optional parameter for a type from the desired assembly</param>
-    /// <example>
-    /// For example:\n
-    /// In a mod assembly called MyMod.dll
-    /// <code>
-    /// public static string MyPath => GetModImagePath("ui/reward_screen/card_transform_reward.png")
-    /// </code>
-    /// results in <c>MyPath = "res://MyMod/images/ui/reward_screen/card_transform_reward.png"</c>
-    /// </example>
-    public static string GetModImagePath(string innerPath, Type? type = null)
-    {
-        // is Assembly.GetCallingAssembly() safe/reliable?
-        return Path.Join("res://" + (type != null ? type.GetRootNamespace() : Assembly.GetCallingAssembly().GetName().Name), "images", innerPath);
+    extension(ImageHelper) {
+        /// <summary>
+        /// Tries to get the image for a given path, including the mod name.\n
+        /// Note that if given the <paramref name="type"/> parameter, this will return the root
+        /// namespace for that type (<c>BaseLib</c> in the case of this mod),
+        /// whereas it will return the assembly name of the calling method if not provided.
+        /// Both of these can differ from the actual path you used if you changed the
+        /// mod's name, or the filepath differs from the one created by the templates
+        /// </summary>
+        /// <param name="innerPath">The path of the .png or otherwise file, without the ModName/images/ section</param>
+        /// <param name="type">Optional parameter for a type from the desired assembly</param>
+        /// <example>
+        /// For example:\n
+        /// In a mod assembly called MyMod.dll
+        /// <code>
+        /// public static string MyPath => GetModImagePath("ui/reward_screen/card_transform_reward.png")
+        /// </code>
+        /// results in <c>MyPath = "res://MyMod/images/ui/reward_screen/card_transform_reward.png"</c>
+        /// </example>
+        public static string GetModImagePath(string innerPath, Type? type = null)
+        {
+            // is Assembly.GetCallingAssembly() safe/reliable?
+            return Path.Join("res://" + (type != null ? type.GetRootNamespace() : Assembly.GetCallingAssembly().GetName().Name), "images", innerPath);
+        }
     }
 }

--- a/Extensions/ModelDbExtensions.cs
+++ b/Extensions/ModelDbExtensions.cs
@@ -8,14 +8,14 @@ public static class ModelDbExtensions
     //Will require language version set to 14 to use.
     extension(ModelDb)
     {
+        /// <summary>
+        /// Obtains a new instance of a CardModifier. Requires language version 14+.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public static T CardModifier<T>() where T : CardModifier
         {
             return ModelDb.Get<T>();
         }
-    }
-
-    public static T GetCardModifier<T>() where T : CardModifier
-    {
-        return ModelDb.CardModifier<T>();
     }
 }

--- a/Extensions/ModelDbExtensions.cs
+++ b/Extensions/ModelDbExtensions.cs
@@ -1,0 +1,21 @@
+﻿using BaseLib.Abstracts;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Extensions;
+
+public static class ModelDbExtensions
+{
+    //Will require language version set to 14 to use.
+    extension(ModelDb)
+    {
+        public static T CardModifier<T>() where T : CardModifier
+        {
+            return ModelDb.Get<T>();
+        }
+    }
+
+    public static T GetCardModifier<T>() where T : CardModifier
+    {
+        return ModelDb.CardModifier<T>();
+    }
+}

--- a/Monsters/ConstructedMove.cs
+++ b/Monsters/ConstructedMove.cs
@@ -1,0 +1,164 @@
+﻿using BaseLib.Audio;
+using BaseLib.Utils;
+using MegaCrit.Sts2.Core.Commands;
+using MegaCrit.Sts2.Core.Entities.Creatures;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.MonsterMoves.Intents;
+using MegaCrit.Sts2.Core.MonsterMoves.MonsterMoveStateMachine;
+
+namespace BaseLib.Monsters;
+
+/// <summary>
+/// Helper class to construct a MoveState without defining a separate function,
+/// while also handling most intents.
+/// </summary>
+public class MoveBuilder
+{
+    public readonly MonsterModel Monster;
+    public readonly string Id;
+
+    public readonly List<Func<IReadOnlyList<Creature>, Task>> Actions = [];
+    public readonly List<AbstractIntent> Intents = [];
+    
+    
+    public MoveBuilder(MonsterModel monster, string id)
+    {
+        Monster = monster;
+        Id = id;
+    }
+
+    /// <summary>
+    /// Adds an attack to the move.
+    /// </summary>
+    /// <param name="damage">Base damage of the attack.</param>
+    /// <param name="hitCount">Number of hits.</param>
+    /// <param name="attackerAnim">Name of animation attacker should play, duration of wait for animation, and whether animation should play on every hit.</param>
+    /// <param name="attackerVfx"></param>
+    /// <param name="attackerSfx"></param>
+    /// <param name="attackerTmpSfx"></param>
+    /// <param name="hitVfx"></param>
+    /// <param name="hitSfx"></param>
+    /// <param name="hitTmpSfx"></param>
+    /// <returns></returns>
+    public MoveBuilder Attack(int damage, int hitCount = 1, 
+        (string, float, bool)? attackerAnim = null, string? attackerVfx = null, string? attackerSfx = null, string? attackerTmpSfx = null,
+        string? hitVfx = null, string? hitSfx = null, string? hitTmpSfx = null)
+    {
+        Actions.Add(async _ =>
+        {
+            var cmd = MonsterActions.Attack(Monster, damage, hitCount)
+                .WithAttackerFx(attackerVfx, attackerSfx, attackerTmpSfx)
+                .WithHitFx(hitVfx, hitSfx, hitTmpSfx);
+
+            if (attackerAnim.HasValue)
+            {
+                cmd.WithAttackerAnim(attackerAnim.Value.Item1, attackerAnim.Value.Item2);
+                if (!attackerAnim.Value.Item3)
+                {
+                    cmd.OnlyPlayAnimOnce();
+                }
+            }
+
+            await cmd.Execute(null);
+        });
+
+        if (hitCount != 1)
+        {
+            Intents.Add(new MultiAttackIntent(damage, hitCount));
+        }
+        else
+        {
+            Intents.Add(new SingleAttackIntent(damage));
+        }
+        
+        return this;
+    }
+
+    /// <summary>
+    /// Plays a sound using a specified key.
+    /// </summary>
+    public MoveBuilder PlaySfx(string key)
+    {
+        Actions.Add(_ =>
+        {
+            SfxCmd.Play(key);
+            return Task.CompletedTask;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Plays a sound defined using ModSound.
+    /// </summary>
+    public MoveBuilder PlaySfx(ModSound sound, float volumeAdd = 0f, float volumeMult = 1f, float pitchVariation = 0f, float basePitch = 1f)
+    {
+        Actions.Add(_ =>
+        {
+            sound.Play(volumeAdd, volumeMult, pitchVariation, basePitch);
+            return Task.CompletedTask;
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Plays one of the creature's animations.
+    /// </summary>
+    public MoveBuilder PlayAnim(string animKey, float waitTime)
+    {
+        Actions.Add(async _ =>
+        {
+            await CreatureCmd.TriggerAnim(Monster.Creature, animKey, waitTime);
+        });
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom defined action to the action list.
+    /// </summary>
+    public MoveBuilder CustomAction(Func<IReadOnlyList<Creature>, Task> action)
+    {
+        Actions.Add(action);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an intent to the intent list.
+    /// </summary>
+    public MoveBuilder AddIntent(AbstractIntent intent)
+    {
+        Intents.Add(intent);
+        return this;
+    }
+
+    /// <summary>
+    /// Constructs MoveState from options supplied to builder.
+    /// </summary>
+    public MoveState Build()
+    {
+        return new MoveState(Id, new ActionExecutor(Actions), Intents.ToArray());
+    }
+    
+    /// <summary>
+    /// Implicit conversion to MoveState. Same result as calling <see cref="Build"/>.
+    /// </summary>
+    public static implicit operator MoveState(MoveBuilder builder)
+    {
+        return builder.Build();
+    }
+
+    private class ActionExecutor(List<Func<IReadOnlyList<Creature>, Task>> actions)
+    {
+        private List<Func<IReadOnlyList<Creature>, Task>> Actions { get; } = actions;
+
+        public static implicit operator Func<IReadOnlyList<Creature>, Task>(ActionExecutor executor)
+        {
+            return async creatures =>
+            {
+                foreach (var action in executor.Actions)
+                {
+                    await action(creatures);
+                }
+            };
+        }
+    }
+}

--- a/Monsters/MoveBuilder.cs
+++ b/Monsters/MoveBuilder.cs
@@ -5,6 +5,7 @@ using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Models;
 using MegaCrit.Sts2.Core.MonsterMoves.Intents;
 using MegaCrit.Sts2.Core.MonsterMoves.MonsterMoveStateMachine;
+using MegaCrit.Sts2.Core.ValueProps;
 
 namespace BaseLib.Monsters;
 
@@ -14,12 +15,48 @@ namespace BaseLib.Monsters;
 /// </summary>
 public class MoveBuilder
 {
+    public enum PowerIntent
+    {
+        None,
+        Buff,
+        Debuff,
+        StrongDebuff
+    }
+    
     public readonly MonsterModel Monster;
     public readonly string Id;
 
     public readonly List<Func<IReadOnlyList<Creature>, Task>> Actions = [];
     public readonly List<AbstractIntent> Intents = [];
-    
+
+    public string? FollowUpStateId { get; set; } = null;
+
+
+
+    private void AddNewIntent<T>() where T : AbstractIntent, new()
+    {
+        if (Intents.Any(intent => intent is T))
+            return;
+        
+        Intents.Add(new T());
+    }
+    private void AddDebuffIntent(bool strong)
+    {
+        var debuffIndex = Intents.FindIndex(intent =>
+            intent.IntentType is IntentType.Debuff or IntentType.DebuffStrong);
+        if (debuffIndex >= 0)
+        {
+            if (Intents[debuffIndex].IntentType == IntentType.DebuffStrong || !strong)
+            {
+                return;
+            }
+
+            Intents[debuffIndex] = new DebuffIntent(strong);
+            return;
+        }
+        
+        Intents.Add(new DebuffIntent(strong));
+    }
     
     public MoveBuilder(MonsterModel monster, string id)
     {
@@ -28,7 +65,7 @@ public class MoveBuilder
     }
 
     /// <summary>
-    /// Adds an attack to the move.
+    /// Adds an attack and attack intent.
     /// </summary>
     /// <param name="damage">Base damage of the attack.</param>
     /// <param name="hitCount">Number of hits.</param>
@@ -70,6 +107,96 @@ public class MoveBuilder
         {
             Intents.Add(new SingleAttackIntent(damage));
         }
+        
+        return this;
+    }
+
+    /// <summary>
+    /// Gains Block and adds block intent.
+    /// </summary>
+    /// <returns></returns>
+    public MoveBuilder Block(int amount, ValueProp props = ValueProp.Move)
+    {
+        Actions.Add(async _ =>
+        {
+            await CreatureCmd.GainBlock(Monster.Creature, amount, props, null);
+        });
+        AddNewIntent<DefendIntent>();
+        return this;
+    }
+
+    /// <summary>
+    /// Applies specified power type to all players and adds a debuff intent.
+    /// </summary>
+    public MoveBuilder ApplyToPlayers<T>(int amount, bool isStrongDebuff, bool silent = false) where T : PowerModel
+    {
+        Actions.Add(async creatures =>
+        {
+            await MonsterActions.Apply<T>(Monster, amount, creatures, silent: silent);
+        });
+        AddDebuffIntent(isStrongDebuff);
+        
+        return this;
+    }
+
+    /// <summary>
+    /// Applies specified power type to self and adds a buff intent.
+    /// </summary>
+    public MoveBuilder ApplyToSelf<T>(int amount, bool silent = false) where T : PowerModel
+    {
+        Actions.Add(async _ =>
+        {
+            await MonsterActions.ApplySelf<T>(Monster, amount, silent: silent);
+        });
+        
+        AddNewIntent<BuffIntent>();
+        return this;
+    }
+    
+    /// <summary>
+    /// Applies specified power type to all creatures returned by targets function.
+    /// An intent to add can be specified.
+    /// </summary>
+    public MoveBuilder ApplyToSomeone<T>(int amount, Func<IEnumerable<Creature>> targets, PowerIntent intent = PowerIntent.None, bool silent = false) where T : PowerModel
+    {
+        Actions.Add(async _ =>
+        {
+            await MonsterActions.Apply<T>(Monster, amount, targets(), silent: silent);
+        });
+
+        switch (intent)
+        {
+            case PowerIntent.Buff:
+                AddNewIntent<BuffIntent>();
+                break;
+            case PowerIntent.Debuff:
+                AddDebuffIntent(false);
+                break;
+            case PowerIntent.StrongDebuff:
+                AddDebuffIntent(true);
+                break;
+        }
+        
+        return this;
+    }
+
+    /// <summary>
+    /// Heals the monster. If autoScaleWithPlayers is true, amount is multiplied by player count.
+    /// </summary>
+    public MoveBuilder HealSelf(int amount, bool autoScaleWithPlayers = true)
+    {
+        return HealSelf(() => amount * (autoScaleWithPlayers ? Monster.Creature.CombatState!.Players.Count : 1));
+    }
+    /// <summary>
+    /// Heals the monster.
+    /// </summary>
+    public MoveBuilder HealSelf(Func<int> amount)
+    {
+        Actions.Add(async _ =>
+        {
+            await CreatureCmd.Heal(Monster.Creature, amount());
+        });
+        AddNewIntent<HealIntent>();
         
         return this;
     }
@@ -131,13 +258,27 @@ public class MoveBuilder
     }
 
     /// <summary>
+    /// Sets the state ID that will be looked for as the following state.
+    /// </summary>
+    /// <param name="stateId"></param>
+    /// <returns></returns>
+    public MoveBuilder FollowingState(string stateId)
+    {
+        FollowUpStateId = stateId;
+        return this;
+    }
+
+    /// <summary>
     /// Constructs MoveState from options supplied to builder.
     /// </summary>
     public MoveState Build()
     {
-        return new MoveState(Id, new ActionExecutor(Actions), Intents.ToArray());
+        return new MoveState(Id, new ActionExecutor(Actions), Intents.ToArray())
+        {
+            FollowUpStateId = this.FollowUpStateId
+        };
     }
-    
+
     /// <summary>
     /// Implicit conversion to MoveState. Same result as calling <see cref="Build"/>.
     /// </summary>

--- a/Patches/Audio/PlayResourcePatch.cs
+++ b/Patches/Audio/PlayResourcePatch.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 using MegaCrit.Sts2.Core.Nodes.Audio;
 using MegaCrit.Sts2.Core.TestSupport;
 
-namespace BaseLib.Patches.Utils;
+namespace BaseLib.Patches.Audio;
 
 static class PlayResourcePatch
 {
@@ -17,7 +17,8 @@ static class PlayResourcePatch
         {
             if (TestMode.IsOn) return true;
 
-            if (path.StartsWith("res://") && ResourceLoader.Exists(path))
+            if ((path.StartsWith("res://") || path.StartsWith("user://") || path.StartsWith("uid://"))
+                && ResourceLoader.Exists(path))
             {
                 ModAudio.PlaySoundInRun(path, volumeMult: volume);
                 return false;
@@ -35,7 +36,8 @@ static class PlayResourcePatch
         {
             if (TestMode.IsOn) return true;
 
-            if (music.StartsWith("res://") && ResourceLoader.Exists(music))
+            if ((music.StartsWith("res://") || music.StartsWith("user://") || music.StartsWith("uid://"))
+                && ResourceLoader.Exists(music))
             {
                 ModAudio.PlaySoundInRun(new ModSound(music, ModAudio.SoundType.Music));
                 return false;

--- a/Patches/Hooks/AfterCardPlayedPatch.cs
+++ b/Patches/Hooks/AfterCardPlayedPatch.cs
@@ -1,11 +1,13 @@
 ﻿using System.Reflection;
 using System.Reflection.Emit;
+using BaseLib.Abstracts;
 using BaseLib.Cards.Variables;
 using BaseLib.Patches.Features;
 using BaseLib.Utils.Patching;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Commands;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.GameActions.Multiplayer;
 using MegaCrit.Sts2.Core.Hooks;
 
 namespace BaseLib.Patches.Hooks;
@@ -20,10 +22,15 @@ class AfterCardPlayedPatch
             AccessTools.Method(typeof(AfterCardPlayedPatch), nameof(BeforeAfterPlayHooks)), beforeState: original);
     }
 
-    private static async Task BeforeAfterPlayHooks(CardPlay cardPlay)
+    private static async Task BeforeAfterPlayHooks(PlayerChoiceContext choiceContext, CardPlay cardPlay)
     {
         if (PostModInitPatch.CanModifyGameplay)
         {
+            foreach (var modifier in  CardModifier.Modifiers(cardPlay.Card))
+            {
+                await modifier.OnPlay(choiceContext, cardPlay);
+            }
+            
             var refundAmount = cardPlay.Card.DynamicVars.TryGetValue(RefundVar.Key, out var val) ? val.IntValue : 0;
             if (refundAmount > 0 && cardPlay.Resources.EnergySpent > 0)
             {

--- a/Patches/UI/SceneConversionPatch.cs
+++ b/Patches/UI/SceneConversionPatch.cs
@@ -1,11 +1,12 @@
 using System.Reflection;
 using BaseLib.Abstracts;
+using BaseLib.Patches.Content;
 using BaseLib.Utils.NodeFactories;
 using Godot;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Models;
 
-namespace BaseLib.Patches.Content;
+namespace BaseLib.Patches.UI;
 
 /// <summary>
 /// Patches the non-generic PackedScene.Instantiate so that registered scenes

--- a/Utils/BetaMainCompatibility.cs
+++ b/Utils/BetaMainCompatibility.cs
@@ -149,6 +149,17 @@ public class BetaMainCompatibility
                 [],
                 m => m.IsGenericMethod)
             );
+        
+        private static VariableMethod FromPowerInstanceDef = new(
+            (typeof(HoverTipFactory), "FromPower",
+                [typeof(PowerModel), typeof(int?)],
+                [0, 1],
+                m => !m.IsGenericMethod),
+            (typeof(HoverTipFactory), "FromPower",
+                [typeof(PowerModel)],
+                [0],
+                m => !m.IsGenericMethod)
+        );
 
         public static IHoverTip FromPower<T>() where T : PowerModel
         {
@@ -160,6 +171,11 @@ public class BetaMainCompatibility
             {
                 return FromPowerDef.InvokeGeneric<IHoverTip, T>(null)!;
             }
+        }
+
+        public static IHoverTip FromPower(PowerModel power, int? amount = null)
+        {
+            return FromPowerInstanceDef.Invoke<IHoverTip>(null, [power, amount])!;
         }
     }
 
@@ -319,12 +335,20 @@ public class VariableMethod
     
     public void Invoke(object? instance, params object?[] args)
     {
-        _method!.Invoke(instance, args);
+        var finalArgs = new object?[_paramIndicies.Length];
+        for (int i = 0; i < _paramIndicies.Length; ++i)
+            finalArgs[i] = args[_paramIndicies[i]];
+        
+        _method!.Invoke(instance, finalArgs);
     }
     
     public T? Invoke<T>(object? instance, params object?[] args)
     {
-        return (T?) _method!.Invoke(instance, args);
+        var finalArgs = new object?[_paramIndicies.Length];
+        for (int i = 0; i < _paramIndicies.Length; ++i)
+            finalArgs[i] = args[_paramIndicies[i]];
+        
+        return (T?) _method!.Invoke(instance, finalArgs);
     }
     public TReturn? InvokeGeneric<TReturn, TGeneric>(object? instance, params object?[] args)
     {

--- a/Utils/CustomAnimation.cs
+++ b/Utils/CustomAnimation.cs
@@ -64,6 +64,7 @@ public static class CustomAnimation
         {
             foreach (var name in animNames)
             {
+                BaseLibMain.Logger.Debug($"Checking for animation {name}");
                 if (animationTree.HasAnimation(name))
                 {
                     stateMachine.Travel(name);
@@ -82,6 +83,7 @@ public static class CustomAnimation
         {
             foreach (var name in animNames)
             {
+                BaseLibMain.Logger.Debug($"Checking for animation {name}");
                 if (animPlayer.HasAnimation(name))
                 {
                     if (animPlayer.CurrentAnimation.Equals(name))
@@ -103,6 +105,7 @@ public static class CustomAnimation
         {
             foreach (var name in animNames)
             {
+                BaseLibMain.Logger.Debug($"Checking for animation {name}");
                 if (animSprite.SpriteFrames.HasAnimation(name))
                 {
                     animSprite.Play(name);

--- a/Utils/MonsterActions.cs
+++ b/Utils/MonsterActions.cs
@@ -1,4 +1,5 @@
 ﻿using MegaCrit.Sts2.Core.Commands.Builders;
+using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.GameActions.Multiplayer;
 using MegaCrit.Sts2.Core.Models;
 
@@ -21,6 +22,15 @@ public static class MonsterActions
     public static async Task<T?> ApplySelf<T>(MonsterModel monster, int amount, PlayerChoiceContext? context = null, bool silent = false) where T : PowerModel
     {
         return await BetaMainCompatibility.PowerCmd_.Apply.InvokeGeneric<Task<T?>, T>
-            (null, context ?? new ThrowingPlayerChoiceContext(), monster.Creature, (decimal) amount, monster.Creature, null, silent)!;
+            (null, context ?? new ThrowingPlayerChoiceContext(), monster.Creature, amount, monster.Creature, null, silent)!;
+    }
+    
+    /// <summary>
+    /// Applies the power specified as the generic parameter to the provided targets.
+    /// </summary>
+    public static async Task<T?> Apply<T>(MonsterModel monster, int amount, IEnumerable<Creature> targets, PlayerChoiceContext? context = null, bool silent = false) where T : PowerModel
+    {
+        return await BetaMainCompatibility.PowerCmd_.ApplyMulti.InvokeGeneric<Task<T?>, T>
+            (null, context ?? new ThrowingPlayerChoiceContext(), targets, amount, monster.Creature, null, silent)!;
     }
 }

--- a/Utils/NodeFactories/NodeFactory.cs
+++ b/Utils/NodeFactories/NodeFactory.cs
@@ -54,7 +54,7 @@ public abstract class NodeFactory
             return;
         }
 
-        if (!scenePath.StartsWith("res://") && !scenePath.StartsWith("user://"))
+        if (!scenePath.StartsWith("res://") && !scenePath.StartsWith("user://") && !scenePath.StartsWith("uid://"))
         {
             BaseLibMain.Logger.Warn($"Registering non-res or user path '{scenePath}'; assuming res path");
             scenePath = "res://" + scenePath;

--- a/Utils/Patching/AsyncMethodCall.cs
+++ b/Utils/Patching/AsyncMethodCall.cs
@@ -314,7 +314,7 @@ public static class AsyncMethodCall
         
         //Generate combined result
         var instructions = stateSections.Code;
-        //BaseLibMain.Logger.Debug($"CODE:\n{instructions.Join(instruction => instruction.ToString(), "\n")}");
+        //instructions.LogCode();
         //instructions.CheckCode();
         return instructions;
     }

--- a/Utils/Patching/AsyncMethodCall.cs
+++ b/Utils/Patching/AsyncMethodCall.cs
@@ -126,7 +126,7 @@ public static class AsyncMethodCall
         
         BaseLibMain.Logger.Info($"Patching StateMachineType: {stateMachineType.FullName}");
 
-        var stateField = stateMachineType.FindStateMachineField("state");
+        var stateField = stateMachineType.FindStateMachineField("__state");
         var builderField = stateMachineType.FindStateMachineField("t__builder");
 
         var codeList = code.ToList();

--- a/Utils/Patching/AsyncMethodCall.cs
+++ b/Utils/Patching/AsyncMethodCall.cs
@@ -1,14 +1,15 @@
-﻿using System.Reflection;
+﻿using System.Collections.Concurrent;
+using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using BaseLib.Extensions;
+using BaseLib.Utils.Patching.AsyncMethodSections;
 using HarmonyLib;
 
 namespace BaseLib.Utils.Patching;
 
 public static class AsyncMethodCall
 {
-    private enum ResultType
+    internal enum ResultType
     {
         None,
         Named,
@@ -16,51 +17,120 @@ public static class AsyncMethodCall
         ReturnIf
     }
 
-    private static readonly Dictionary<MethodBase, HashSet<string>> AddedNames = [];
-    [ThreadStatic] private static Dictionary<string, object>? AsyncFields;
-    private static Dictionary<string, object> GetAsyncFields {
-        get
-        {
-            AsyncFields ??= new Dictionary<string, object>();
+    internal static readonly MethodInfo StoreStateInDictMethod = typeof(AsyncMethodCall).Method(nameof(StoreStateInDict));
+    internal static readonly MethodInfo LoadStateFromDictMethod = typeof(AsyncMethodCall).Method(nameof(LoadStateFromDict));
 
-            return AsyncFields;
+    internal static readonly MethodInfo StoreDictionaryForStateMethod = typeof(AsyncMethodCall).Method(nameof(StoreDictionaryForState));
+    internal static readonly MethodInfo LoadDictionaryForStateMethod = typeof(AsyncMethodCall).Method(nameof(LoadDictionaryForState));
+    
+    internal static readonly MethodInfo GetAwaiterMethod = typeof(AsyncMethodCall).Method(nameof(GetAwaiter));
+    internal static readonly MethodInfo StoreAwaiterMethod = typeof(AsyncMethodCall).Method(nameof(StoreAwaiter));
+    internal static readonly MethodInfo GetNamedMethod = typeof(AsyncMethodCall).Method(nameof(GetNamed));
+    internal static readonly MethodInfo StoreNamedMethod = typeof(AsyncMethodCall).Method(nameof(StoreNamed));
+    
+
+    internal static readonly InstructionMatcher StateAwaitMatcher = new InstructionMatcher()
+        .any().PredicateMatch(arg =>
+        {
+            switch (arg)
+            {
+                case MethodInfo method
+                    when method.ReturnType.IsAssignableTo(typeof(Task)):
+                case FieldInfo field
+                    when field.FieldType.IsAssignableTo(typeof(Task)):
+                    return true;
+                default:
+                    return false;
+            }
+        })
+        .callvirt(null).PredicateMatch(arg => arg is MethodInfo { Name: "GetAwaiter" });
+    
+    #region external_state_methods
+    
+    private static readonly Dictionary<MethodBase, HashSet<string>> AddedNames = [];
+
+    private static readonly ConcurrentDictionary<int, int> StateDictionary = [];
+    private const int MinKey = -357913941;
+    private const int MaxKey = -178956970;
+    private static int _fakeStateKey = MinKey;
+
+    private static readonly Dictionary<string, object> AwaiterDictionary = [];
+    private static readonly Dictionary<int, Dictionary<string, object>> SavedValuesDictionary = [];
+    
+
+    private static int StoreStateInDict(int stateKey)
+    {
+        int tempKey = Interlocked.Increment(ref _fakeStateKey);
+        if (tempKey > MaxKey)
+        {
+            //May happen twice, but shouldn't cause an issue as tempKey values will remain unique.
+            _fakeStateKey = MinKey;
         }
+
+        if (StateDictionary.ContainsKey(tempKey))
+        {
+            BaseLibMain.Logger.Warn($"Extremely old state key {tempKey} still left in async state dictionary");
+        }
+
+        BaseLibMain.Logger.Debug($"Stored temp state key: {stateKey} -> {tempKey}");
+        StateDictionary[tempKey] = stateKey;
+        return tempKey;
+    }
+    private static int LoadStateFromDict(int stateKey)
+    {
+        if (StateDictionary.Remove(stateKey, out var realState))
+        {
+            BaseLibMain.Logger.Debug($"Loaded state from dict: {stateKey} -> {realState}");
+            return realState;
+        }
+        BaseLibMain.Logger.VeryDebug($"State not in dict: {stateKey}");
+        return stateKey;
     }
 
-    private static readonly MethodInfo GetAwaiterMethod = typeof(AsyncMethodCall).Method("GetAwaiter");
-    private static readonly MethodInfo StoreAwaiterMethod = typeof(AsyncMethodCall).Method("StoreAwaiter");
-    private static readonly MethodInfo GetNamedMethod = typeof(AsyncMethodCall).Method("GetNamed");
-    private static readonly MethodInfo StoreNamedMethod = typeof(AsyncMethodCall).Method("StoreNamed");
-
-    private static object GetAwaiter(object keyObj, int stateIndex)
+    private static void StoreDictionaryForState(int stateKey, Dictionary<string, object> dict)
     {
-        var stringKey = $"{keyObj}_{stateIndex}";
-        //BaseLibMain.Logger.Info($"StringKey {stringKey}");
-        GetAsyncFields.Remove(stringKey, out var result);
-        //BaseLibMain.Logger.Info($"Load awaiter state {stateIndex}: {result}");
+        if (SavedValuesDictionary.ContainsKey(stateKey))
+        {
+            BaseLibMain.Logger.Warn($"Extremely old state key {stateKey} still left in async saved values dictionary");
+        }
+
+        SavedValuesDictionary[stateKey] = dict;
+    }
+    private static Dictionary<string, object> LoadDictionaryForState(int stateKey)
+    {
+        if (SavedValuesDictionary.Remove(stateKey, out var stringDict))
+        {
+            BaseLibMain.Logger.Debug($"Loaded dictionary for state {stateKey}");
+            return stringDict;
+        }
+        return [];
+    }
+
+    private static void StoreAwaiter(object awaiter, int fakeStateIndex) //object keyObj, int stateIndex)
+    {
+        var stringKey = $"__state__{fakeStateIndex}";
+        BaseLibMain.Logger.Debug($"Storing awaiter using fake state key {stringKey}");
+        AwaiterDictionary[stringKey] = awaiter;
+    }
+    private static object GetAwaiter(int fakeStateIndex)
+    {
+        var stringKey = $"__state__{fakeStateIndex}";
+        AwaiterDictionary.Remove(stringKey, out var result);
+        BaseLibMain.Logger.Debug($"Retrieved awaiter state {fakeStateIndex}: {result}");
         return result!;
     }
-    private static void StoreAwaiter(object awaiter, object keyObj, int stateIndex)
+    
+    private static object GetNamed(Dictionary<string, object> dict, string name)
     {
-        var stringKey = $"{keyObj}_{stateIndex}";
-        //BaseLibMain.Logger.Info($"StringKey {stringKey}");
-        GetAsyncFields[stringKey] = awaiter;
-        //BaseLibMain.Logger.Info($"Store awaiter state {stateIndex}: {awaiter}");
+        BaseLibMain.Logger.Debug($"Load awaiter val {name}");
+        return dict[name];
     }
-    private static object GetNamed(object keyObj, string name)
+    private static void StoreNamed(object val, Dictionary<string, object> dict, string name)
     {
-        var stringKey = keyObj + name;
-        var result = GetAsyncFields[stringKey];
-        //BaseLibMain.Logger.Info($"Load awaiter val {name}: {result}");
-        //TODO - clean out named fields at some point? Add removal to end of state machine
-        return result;
+        dict[name] = val;
+        BaseLibMain.Logger.Debug($"Store awaiter val {name}: {val}");
     }
-    private static void StoreNamed(object val, object keyObj, string name)
-    {
-        var stringKey = keyObj + name;
-        GetAsyncFields[stringKey] = val;
-        //BaseLibMain.Logger.Info($"Store awaiter val {name}: {val}");
-    }
+    #endregion
 
 
     /// <summary>
@@ -124,217 +194,35 @@ public static class AsyncMethodCall
                                throw new ArgumentException(
                                    $"Failed to get state machine type from method '{original.FullDescription()}'");
         
-        BaseLibMain.Logger.Info($"Patching StateMachineType: {stateMachineType.FullName}");
+        BaseLibMain.Logger.Info($"Patching state machine: {stateMachineType.FullName}");
 
-        var stateField = stateMachineType.FindStateMachineField("__state");
-        var builderField = stateMachineType.FindStateMachineField("t__builder");
-
-        var codeList = code.ToList();
-        
-        int index = 0;
-        
-        List<CodeInstruction> loadStateSection = new();
-        while (index < codeList.Count)
+        AsyncMethodContext context = new()
         {
-            if (codeList[index].HasBlock(ExceptionBlockType.BeginExceptionBlock))
-            {
-                break;
-            }
-            loadStateSection.Add(codeList[index]);
-            ++index;
+            Generator = generator,
+            BuilderField = stateMachineType.FindStateMachineField("t__builder"),
+            StateField = stateMachineType.FindStateMachineField("__state"),
+            StateMachineType = stateMachineType
+        };
+
+        MoveNextSection stateSections;
+        using (var codeEnumerator = code.GetEnumerator()) {
+            codeEnumerator.MoveNext();
+            stateSections = MoveNextSection.Read(context, codeEnumerator);
         }
         
-        List<CodeInstruction> branchSection = new();
-        
-        //First, analyze initial branching to determine starts of each state branch.
-        //If branch is conditional, determine required state. If conditional branch destination is an unconditional branch, update that state's position.
-        Dictionary<int, Label> stateLabels = [];
-        int? checkState = null;
-        
-        bool exitLoop = false;
-        
-        while (index < codeList.Count && !exitLoop)
-        {
-            var instruction = codeList[index];
-            if (instruction.opcode == OpCodes.Ldloc_0)
-            {
-                branchSection.Add(instruction);
-            }
-            else if (instruction.opcode == OpCodes.Switch)
-            {
-                var labelArr = (Label[]) instruction.operand;
-                for (int i = 0; i < labelArr.Length; ++i)
-                {
-                    stateLabels[i] = labelArr[i];
-                }
-                branchSection.Add(instruction);
-                ++index;
-                break;
-            }
-            else if (instruction.TryGetIntValue(out var loadedConst))
-            {
-                checkState = loadedConst;
-                branchSection.Add(instruction);
-            }
-            else
-            {
-                switch (instruction.opcode.Value)
-                {
-                    case (int) OpCodeValues.Brfalse_S:
-                    case (int) OpCodeValues.Brfalse: //Branch if current state == 0
-                        stateLabels[0] = (Label)instruction.operand;
-                        //BaseLibMain.Logger.Info($"State 0 dest {stateLabels[0].Id}");
-                        break;
-                    case (int) OpCodeValues.Brtrue_S:
-                    case (int) OpCodeValues.Brtrue: //What
-                        BaseLibMain.Logger.Warn("Unexpected Brtrue in jump section of state machine");
-                        break;
-                    case (int) OpCodeValues.Beq_S:
-                    case (int) OpCodeValues.Beq: //Branch if current state == ?
-                        if (checkState == null)
-                        {
-                            BaseLibMain.Logger.Warn("Failed to evaluate beq, checkState null");
-                            break;
-                        }
-                        stateLabels[checkState.Value] = (Label)instruction.operand;
-                        //BaseLibMain.Logger.Info($"State {checkState.Value} dest {stateLabels[checkState.Value].Id}");
-                        break;
-                    case (int) OpCodeValues.Br_S:
-                    case (int) OpCodeValues.Br: //Unconditional branch. State -1 or intermediate jump.
-                        var opLabel = (Label)instruction.operand;
-                        foreach (var entry in stateLabels)
-                        {
-                            foreach (var label in instruction.labels)
-                            {
-                                if (entry.Value == label)
-                                {
-                                    stateLabels[entry.Key] = opLabel;
-                                    //BaseLibMain.Logger.Info($"State {entry.Key} dest {stateLabels[entry.Key].Id}");
-                                    break;
-                                }
-                            }
-                        }
-                        break;
-                    default:
-                        //BaseLibMain.Logger.Info($"Found end of branching section");
-                        exitLoop = true;
-
-                        if (instruction.opcode == OpCodes.Nop)
-                        {
-                            branchSection.Add(instruction);
-                            ++index;
-                        }
-                        
-                        break;
-                }
-
-                if (!exitLoop)
-                    branchSection.Add(instruction);
-                else
-                    break;
-            }
-
-            ++index;
-        }
-
-        Dictionary<Label, int> labelStates = [];
-        foreach (var entry in stateLabels)
-        {
-            labelStates[entry.Value] = entry.Key;
-            //BaseLibMain.Logger.Info($"State {entry.Key} dest label {entry.Value.Id}");
-        }
-        
-        //Finished checking branching section; check states
-        List<CodeInstruction>? betweenSection = null;
-        List<StateInfo> states = [];
-        HashSet<Label> leaveLabels = [];
-        int newStateIndex = states.Count;
-        
-        int currentState = -3;
-        List<CodeInstruction> stateSection = [];
-        bool endingState = false; //Set to true upon reaching GetResult. Next instruction is included in state if it is stloc, nop, or pop
-        
-        while (index < codeList.Count)
-        {
-            var instruction = codeList[index];
-            foreach (var label in instruction.labels)
-            {
-                if (labelStates.TryGetValue(label, out var state))
-                {
-                    //BaseLibMain.Logger.Info($"Found state resume point label {label.Id} for state {state}");
-                    currentState = state;
-                }
-            }
-
-            if (instruction.opcode == OpCodes.Leave || instruction.opcode == OpCodes.Leave_S)
-            {
-                if (instruction.operand is Label label)
-                {
-                    leaveLabels.Add(label);
-                }
-            }
-            
-            //Check for ending of state
-            if (instruction.opcode == OpCodes.Call && instruction.operand is MethodInfo { Name: "GetResult" } methodInfo && (methodInfo.DeclaringType?.Name.StartsWith("TaskAwaiter") ?? false))
-            {
-                endingState = true;
-                stateSection.Add(instruction);
-            }
-            else if (endingState)
-            {
-                endingState = false;
-                switch (currentState)
-                {
-                    case -3:
-                        BaseLibMain.Logger.Warn("Found code between branching section and states");
-                        betweenSection = stateSection;
-                        break;
-                    case -2:
-                        throw new Exception("Failed to find index of state");
-                    default:
-                        if (instruction.IsStloc() || instruction.opcode == OpCodes.Nop || instruction.opcode == OpCodes.Pop)
-                        {
-                            stateSection.Add(instruction);
-                        }
-                        else
-                        {
-                            --index; //Use this instruction as start of next state.
-                        }
-                        var nextState = new StateInfo(currentState, stateSection, stateField);
-                        states.Add(nextState);
-                        if (nextState.Index >= newStateIndex)
-                            newStateIndex = nextState.Index + 1;
-                        break;
-                }
-
-                stateSection = [];
-                currentState = -2;
-            }
-            else
-            {
-                stateSection.Add(instruction);
-            }
-
-            ++index;
-        }
-        
-        //Remaining code is "ending" of MoveNext
-        var endingSection = stateSection;
-        //BaseLibMain.Logger.Info($"Found {leaveLabels.Count} labels for leave instructions [{leaveLabels.Join(label => label.Id.ToString())}]");
-        
-        if (states.Count == 0)
+        if (!stateSections.AllStates.Any())
             throw new Exception($"Failed to find any states for async method {original.Name}");
 
         //Find target state
         StateInfo? targetState = null;
         if (targetMethod == original)
         {
-            targetState = before ? states[0] : states[^1];
+            targetState = before ? stateSections.AllStates.First() : stateSections.AllStates.Last();
             targetMethod = targetState.StateMethod;
         }
         else
         {
-            foreach (var state in states)
+            foreach (var state in stateSections.AllStates)
             {
                 if (state.StateMethod == targetMethod)
                 {
@@ -347,53 +235,16 @@ public static class AsyncMethodCall
         if (targetState == null)
             throw new ArgumentException($"Unable to find state for target method {targetMethod?.Name}");
         
-        //Analyze ending section
-        Type? returnType = null;
-        Label retLabel = default, retValLabel = default;
-        foreach (var ci in endingSection)
-        {
-            foreach (var label in ci.labels)
-            {
-                if (leaveLabels.Remove(label))
-                {
-                    if (ci.opcode == OpCodes.Ret)
-                    {
-                        retLabel = label;
-                    }
-                    else
-                    {
-                        retValLabel = label;
-                    }
-                }
-            }
-            
-            if (returnType != null || ci.opcode != OpCodes.Call || ci.operand is not MethodInfo { Name: "SetResult" } info) continue;
-            
-            var declaringType = info.DeclaringType;
-            if (declaringType == null) continue;
-
-            if (declaringType == typeof(AsyncTaskMethodBuilder)
-                || declaringType == typeof(AsyncValueTaskMethodBuilder))
-            {
-                continue;
-            }
-            if (declaringType.IsConstructedGenericType 
-                && (declaringType.GetGenericTypeDefinition() == typeof(AsyncTaskMethodBuilder<>)
-                    || declaringType.GetGenericTypeDefinition() == typeof(AsyncValueTaskMethodBuilder<>)))
-            {
-                returnType = declaringType.GenericTypeArguments[0];
-            }
-        }
+        //Generate getters/setters for fields that match target method parameter names
+        var methodCallParams = callMethod.GetParameters()
+            .Select(param => MakeStateParameter(original, context, stateSections.LoadSection.StringDictLocal, param)).ToList();
         
-        //BaseLibMain.Logger.Info($"Return label: {retLabel.Id}");
-        //BaseLibMain.Logger.Info($"Return value label: {retValLabel.Id}");
-        
-        //Look for fields that match target method parameter names
-        var methodCallParams = callMethod.GetParameters().Select(param => MakeStateParameter(original, stateMachineType, param)).ToList();
         var resultType = resultName?.ToLowerInvariant() == "return" ? ResultType.Return : 
             resultName?.ToLowerInvariant() == "returnif" ? ResultType.ReturnIf : 
             resultName != null ? ResultType.Named : ResultType.None;
 
+        var returnType = stateSections.EndingSection.ReturnType;
+        
         switch (resultType)
         {
             case ResultType.Return:
@@ -452,40 +303,19 @@ public static class AsyncMethodCall
                 break;
         }
         
-        BaseLibMain.Logger.Info($"Adding new state {newStateIndex} for method {callMethod.DeclaringType?.Name ?? "???"}.{callMethod.Name} {(before ? "before" : "after")} {targetMethod?.Name ?? targetState.Index.ToString()} with result type {resultType} ({resultName})");
+        BaseLibMain.Logger.Info($"Adding new state {context.NextStateIndex} for method {callMethod.DeclaringType?.Name ?? "???"}.{callMethod.Name} {(before ? "before" : "after")} {targetMethod?.Name ?? targetState.Index.ToString()} with result type {resultType} ({resultName})");
         
-        //Generate label and branch instruction
-        var loadStateLabel = generator.DefineLabel();
-        
-        branchSection = [
-            // .."Start of branch section".MakeWriteLog(),
-            CodeInstruction.LoadLocal(0).WithBlocks(branchSection[0].ExtractBlocks()),
-            newStateIndex.LoadConstant(),
-            new CodeInstruction(OpCodes.Beq, loadStateLabel),
-            ..branchSection
-        ];
-
-        //Insert new state
-        targetState.Insert(before, newStateIndex, callMethod, methodCallParams, 
-            stateMachineType, stateField, builderField, 
-            loadStateLabel, retLabel, retValLabel, resultType, resultName, generator);
+        //Generate new state
+        stateSections.InsertState(context, before, targetState, callMethod, methodCallParams, resultType, resultName);
         
         //Generate combined result
-        var instructions = new List<CodeInstruction>();
-        instructions.AddRange(loadStateSection);
-        instructions.AddRange(branchSection);
-        if (betweenSection != null) instructions.AddRange(betweenSection);
-        foreach (var state in states)
-        {
-            instructions.AddRange(state.Code);
-        }
-        instructions.AddRange(endingSection);
-        
-        //BaseLibMain.Logger.Info($"CODE:\n{instructions.Join(instruction => instruction.ToString(), "\n")}");
+        var instructions = stateSections.Code;
+        BaseLibMain.Logger.Debug($"CODE:\n{instructions.Join(instruction => instruction.ToString(), "\n")}");
+        instructions.CheckCode();
         return instructions;
     }
 
-    private static StateParamInfo MakeStateParameter(MethodBase method, Type stateMachineType, ParameterInfo param)
+    private static StateParamInfo MakeStateParameter(MethodBase method, AsyncMethodContext context, int stringDictLocal, ParameterInfo param)
     {
         if (param.Name == null) throw new Exception("Unable to determine parameter name for method to call for async method call");
 
@@ -496,7 +326,7 @@ public static class AsyncMethodCall
         {
             if (method.IsStatic)
                 throw new ArgumentException("Unable to use __instance parameter when patching static method");
-            var thisField = stateMachineType.FindStateMachineField("__this");
+            var thisField = context.StateMachineType.FindStateMachineField("__this");
 
             addLoadInstructions = list =>
             {
@@ -510,10 +340,10 @@ public static class AsyncMethodCall
         }
         else if (AddedNames.TryGetValue(method, out var dict) && dict.Contains(param.Name))
         {
-            BaseLibMain.Logger.Info($"Using named result {param.Name} in method {method.Name}");
+            BaseLibMain.Logger.Debug($"Using named result {param.Name} in method {method.Name}");
             addLoadInstructions = list =>
             {
-                list.AddRange(stateMachineType.BoxArg0());
+                list.Add(CodeInstruction.LoadLocal(stringDictLocal));
                 list.Add(new CodeInstruction(OpCodes.Ldstr, param.Name));
                 list.Add(GetNamedMethod.Call());
                 if (param.ParameterType.IsValueType)
@@ -527,14 +357,14 @@ public static class AsyncMethodCall
                 {
                     list.Add(new CodeInstruction(OpCodes.Box, param.ParameterType));
                 }
-                list.AddRange(stateMachineType.BoxArg0());
+                list.Add(CodeInstruction.LoadLocal(stringDictLocal));
                 list.Add(new CodeInstruction(OpCodes.Ldstr, param.Name));
                 list.Add(StoreNamedMethod.Call());
             };
         }
         else
         {
-            var field = stateMachineType.FindStateMachineField(param.Name);
+            var field = context.StateMachineType.FindStateMachineField(param.Name);
             if (!field.FieldType.IsAssignableTo(param.ParameterType))
             {
                 throw new ArgumentException(
@@ -555,237 +385,5 @@ public static class AsyncMethodCall
         }
         
         return new StateParamInfo(param, addLoadInstructions, addStoreInstructions);
-    }
-    
-
-    private static readonly InstructionMatcher StateAwaitMatcher = new InstructionMatcher()
-        .any().PredicateMatch(arg =>
-        {
-            switch (arg)
-            {
-                case MethodInfo method
-                    when method.ReturnType.IsAssignableTo(typeof(Task)):
-                case FieldInfo field
-                    when field.FieldType.IsAssignableTo(typeof(Task)):
-                    return true;
-                default:
-                    return false;
-            }
-        })
-        .callvirt(null).PredicateMatch(arg => arg is MethodInfo { Name: "GetAwaiter" });
-
-    private record StateParamInfo(
-        ParameterInfo Parameter,
-        Action<List<CodeInstruction>> AddLoadInstructions,
-        Action<List<CodeInstruction>> AddStoreInstructions);
-
-    private class StateInfo //, MethodBase stateMethod, int indexLoadIndex)
-    {
-        public int Index { get; }
-        public List<CodeInstruction> Code { get; private set; }
-        public MethodInfo? StateMethod { get; }
-        
-        public StateInfo(int index, List<CodeInstruction> code, FieldInfo stateField)
-        {
-            Index = index;
-            Code = code;
-
-            StateMethod = AnalyzeCode(stateField, Index, Code);
-        }
-
-        private static MethodInfo? AnalyzeCode(FieldInfo stateField, int stateIndex, List<CodeInstruction> code)
-        {
-            var storeStateMatcher = new InstructionMatcher().stfld(stateField);
-
-            InstructionPatcher reader = new(code);
-        
-            bool[] matched = [true];
-            reader.Match(_ => matched[0] = false, StateAwaitMatcher);
-            if (!matched[0])
-            {
-                BaseLibMain.Logger.Info($"CODE:\n{code.Join(instruction => instruction.ToString(), "\n")}");
-                throw new InvalidOperationException($"Failed to find state awaiter for state {stateIndex}");
-            }
-
-            reader
-                .Step(-2).GetOperand(out var operand) //Get method called to get awaited task
-                .Step(3)
-                .Match(storeStateMatcher); //Move to next state store (occurs when awaited task does not end immediately)
-            
-            return operand as MethodInfo;
-        }
-
-        public void Insert(bool before, int newStateIndex, MethodInfo callMethod, IEnumerable<StateParamInfo> loadFields,
-            Type stateMachineType, FieldInfo stateField, FieldInfo builderField,
-            Label loadStateLabel, Label retLabel, Label retValLabel, ResultType resultType, string? resultName,
-            ILGenerator generator)
-        {
-            var awaiterType = typeof(TaskAwaiter);
-            var taskMethodBuilderType = builderField.FieldType;
-            var valueTypeMachine = stateMachineType.IsValueType;
-
-            var returnType = typeof(void);
-            if (callMethod.ReturnType.IsGenericType)
-            {
-                returnType = callMethod.ReturnType.GetGenericArguments()[0];
-                BaseLibMain.Logger.Info($"Method to call has return type; making generic awaiter type [{returnType}]");
-                awaiterType = typeof(TaskAwaiter<>).MakeGenericType(returnType);
-            }
-            
-            var taskGetAwaiter = callMethod.ReturnType.GetMethod("GetAwaiter");
-            if (taskGetAwaiter == null)
-                throw new Exception($"Failed to get GetAwaiter for type {callMethod.ReturnType}");
-
-            var awaitUnsafe = taskMethodBuilderType.GetMethod("AwaitUnsafeOnCompleted");
-            if (awaitUnsafe == null)
-                throw new Exception($"Failed to get AwaitUnsafeOnCompleted for type {taskMethodBuilderType}");
-            if (awaitUnsafe.IsGenericMethodDefinition)
-            {
-                awaitUnsafe = awaitUnsafe.MakeGenericMethod(awaiterType, stateMachineType);
-            }
-            
-            var taskAwaiter = generator.DeclareLocal(awaiterType);
-            var isCompleted = awaiterType.PropertyGetter("IsCompleted");
-            
-            var endingSectionLabel = generator.DefineLabel();
-            
-            //Initial method call
-            List<CodeInstruction> newCode = [];
-            StateParamInfo? resultParam = null;
-
-            foreach (var loadField in loadFields) //Load fields as parameters for method
-            {
-                if (resultType == ResultType.Named && loadField.Parameter.Name == resultName)
-                {
-                    resultParam = loadField;
-                }
-                loadField.AddLoadInstructions(newCode);
-            }
-
-            if (resultParam != null)
-            {
-                //Validate result param type
-                if (!returnType.IsAssignableTo(resultParam.Parameter.ParameterType))
-                {
-                    throw new ArgumentException(
-                        $"Cannot store method result of type {returnType} to parameter {resultParam.Parameter.Name} of type {resultParam.Parameter.ParameterType}");
-                }
-            }
-            
-            //newCode.AddRange("Loaded Fields".MakeWriteLog());
-            newCode.Add(new CodeInstruction(OpCodes.Call, callMethod));
-            newCode.Add(taskGetAwaiter.CallVirt());
-            //newCode.AddRange("Store awaiter".MakeWriteLog());
-            newCode.Add(CodeInstruction.StoreLocal(taskAwaiter.LocalIndex));
-            newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true));
-            newCode.Add(new CodeInstruction(OpCodes.Call, isCompleted));
-            newCode.Add(new CodeInstruction(OpCodes.Brtrue, endingSectionLabel)); //if already complete, skip to end
-            
-            //await block
-            //newCode.AddRange("Await Block".MakeWriteLog());
-            newCode.Add(CodeInstruction.LoadArgument(0)); //load "this" for stfld
-            newCode.Add(newStateIndex.LoadConstant());
-            newCode.Add(new CodeInstruction(OpCodes.Dup));
-            newCode.Add(CodeInstruction.StoreLocal(0)); //Store state in local 0
-            newCode.Add(stateField.Stfld()); //and in state field
-            
-            newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex)); //load awaiter and store in external dict
-            newCode.Add(new CodeInstruction(OpCodes.Box, awaiterType));
-            newCode.AddRange(stateMachineType.BoxArg0()); //Use state machine object as key
-            newCode.Add(newStateIndex.LoadConstant()); //state index
-            newCode.Add(StoreAwaiterMethod.Call());
-            
-            newCode.Add(CodeInstruction.LoadArgument(0)); //Get builder and AwaitUnsafeOnCompleted
-            newCode.Add(new CodeInstruction(OpCodes.Ldflda, builderField));
-            newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true));
-            newCode.Add(CodeInstruction.LoadArgument(0, !valueTypeMachine)); //Need to treat valuetype state machine differently or state is lost on await
-            //newCode.AddRange("Awaiting".MakeWriteLog());
-            newCode.Add(awaitUnsafe.Call());
-            newCode.Add(new CodeInstruction(OpCodes.Leave, retLabel));
-            
-            //Section 3 - restore state
-            newCode.Add(new CodeInstruction(OpCodes.Nop).WithLabels(loadStateLabel));
-            //newCode.AddRange("Load State".MakeWriteLog());
-            newCode.AddRange(stateMachineType.BoxArg0()); //Get awaiter from dict
-            newCode.Add(newStateIndex.LoadConstant());
-            newCode.Add(GetAwaiterMethod.Call());
-            //newCode.AddRange("Got Awaiter".MakeWriteLog());
-            newCode.Add(new CodeInstruction(OpCodes.Unbox_Any, awaiterType));
-            newCode.Add(CodeInstruction.StoreLocal(taskAwaiter.LocalIndex)); //Store in local
-            //Code to reset field, not necessary due to external store
-            //newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true)); //Load as address from local
-            //newCode.Add(new CodeInstruction(OpCodes.Initobj, awaiterType)); //Init with address
-            //newCode.AddRange("Initialized Awaiter".MakeWriteLog());
-            
-            newCode.Add(CodeInstruction.LoadArgument(0)); //Set state to -1
-            newCode.Add((-1).LoadConstant());
-            newCode.Add(new CodeInstruction(OpCodes.Dup));
-            newCode.Add(CodeInstruction.StoreLocal(0));
-            newCode.Add(stateField.Stfld());
-            //newCode.AddRange("Set state to -1".MakeWriteLog());
-            
-            //Section 4 - get result
-            newCode.Add(new CodeInstruction(OpCodes.Nop).WithLabels(endingSectionLabel));
-            newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true));
-            //newCode.AddRange("Loaded awaiter local address".MakeWriteLog());
-            newCode.Add(CodeInstruction.Call(awaiterType, "GetResult"));
-            //newCode.AddRange("Got result".MakeWriteLog());
-
-            //Can do 3 things with result:
-            //Store (in resultParam or by name)
-            //Return
-            //Ignore
-            switch (resultType)
-            {
-                case ResultType.Return:
-                    newCode.Add(returnType == typeof(void)
-                        ? new CodeInstruction(OpCodes.Nop)
-                        : CodeInstruction.StoreLocal(1));
-                    newCode.Add(new CodeInstruction(OpCodes.Leave, retValLabel));
-                    break;
-                case ResultType.ReturnIf:
-                    //Currently a bool on stack.
-                    Label skipLeaveLabel = generator.DefineLabel();
-                    newCode.Add(new CodeInstruction(OpCodes.Brfalse_S, skipLeaveLabel));
-                    newCode.Add(new CodeInstruction(OpCodes.Leave, retValLabel));
-                    newCode.Add(new CodeInstruction(OpCodes.Nop).WithLabels(skipLeaveLabel));
-                    break;
-                case ResultType.Named:
-                    if (resultParam != null)
-                    {
-                        resultParam.AddStoreInstructions(newCode);
-                    }
-                    else if (resultName != null)
-                    {
-                        if (returnType.IsValueType)
-                        {
-                            newCode.Add(new CodeInstruction(OpCodes.Box, returnType));
-                        }
-                        newCode.AddRange(stateMachineType.BoxArg0());
-                        newCode.Add(new CodeInstruction(OpCodes.Ldstr, resultName));
-                        newCode.Add(StoreNamedMethod.Call());
-                    }
-                    break;
-                default:
-                    //Don't need to keep result.
-                    newCode.Add(new CodeInstruction(returnType == typeof(void) ? OpCodes.Nop : OpCodes.Pop));
-                    break;
-            }
-
-            if (before)
-            {
-                Code = [
-                    ..newCode,
-                    ..Code
-                ];
-            }
-            else
-            {
-                Code = [
-                    ..Code,
-                    ..newCode
-                ];
-            }
-        }
     }
 }

--- a/Utils/Patching/AsyncMethodCall.cs
+++ b/Utils/Patching/AsyncMethodCall.cs
@@ -310,8 +310,8 @@ public static class AsyncMethodCall
         
         //Generate combined result
         var instructions = stateSections.Code;
-        BaseLibMain.Logger.Debug($"CODE:\n{instructions.Join(instruction => instruction.ToString(), "\n")}");
-        instructions.CheckCode();
+        //BaseLibMain.Logger.Debug($"CODE:\n{instructions.Join(instruction => instruction.ToString(), "\n")}");
+        //instructions.CheckCode();
         return instructions;
     }
 

--- a/Utils/Patching/AsyncMethodCall.cs
+++ b/Utils/Patching/AsyncMethodCall.cs
@@ -7,6 +7,10 @@ using HarmonyLib;
 
 namespace BaseLib.Utils.Patching;
 
+/// <summary>
+/// Utility class for patching async method state machines.
+/// Can generate additional states to call an async method.
+/// </summary>
 public static class AsyncMethodCall
 {
     internal enum ResultType
@@ -23,12 +27,12 @@ public static class AsyncMethodCall
     internal static readonly MethodInfo StoreDictionaryForStateMethod = typeof(AsyncMethodCall).Method(nameof(StoreDictionaryForState));
     internal static readonly MethodInfo LoadDictionaryForStateMethod = typeof(AsyncMethodCall).Method(nameof(LoadDictionaryForState));
     
-    internal static readonly MethodInfo GetAwaiterMethod = typeof(AsyncMethodCall).Method(nameof(GetAwaiter));
     internal static readonly MethodInfo StoreAwaiterMethod = typeof(AsyncMethodCall).Method(nameof(StoreAwaiter));
-    internal static readonly MethodInfo GetNamedMethod = typeof(AsyncMethodCall).Method(nameof(GetNamed));
-    internal static readonly MethodInfo StoreNamedMethod = typeof(AsyncMethodCall).Method(nameof(StoreNamed));
+    internal static readonly MethodInfo GetAwaiterMethod = typeof(AsyncMethodCall).Method(nameof(GetAwaiter));
     
-
+    internal static readonly MethodInfo StoreNamedMethod = typeof(AsyncMethodCall).Method(nameof(StoreNamed));
+    internal static readonly MethodInfo GetNamedMethod = typeof(AsyncMethodCall).Method(nameof(GetNamed));
+    
     internal static readonly InstructionMatcher StateAwaitMatcher = new InstructionMatcher()
         .any().PredicateMatch(arg =>
         {

--- a/Utils/Patching/AsyncMethodSections/AsyncMethodContext.cs
+++ b/Utils/Patching/AsyncMethodSections/AsyncMethodContext.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+public class AsyncMethodContext
+{
+    public required ILGenerator Generator;
+    public required FieldInfo StateField;
+    public required FieldInfo BuilderField;
+
+    public required Type StateMachineType;
+
+    public int NextStateIndex = 0;
+}

--- a/Utils/Patching/AsyncMethodSections/BranchSection.cs
+++ b/Utils/Patching/AsyncMethodSections/BranchSection.cs
@@ -1,0 +1,318 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using BaseLib.Extensions;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+//TODO - Handle more unusual cases with branching (see CombatManager.ExecuteEnemyTurn)
+internal class BranchSection : IAsyncStateSection
+{
+    public static IAsyncStateSection Read(AsyncMethodContext context, LoadStateSection loadStateSection, BranchingStateSection branchSource, IEnumerator<CodeInstruction> codeEnumerator)
+    {
+        //If this is another branching section, initial parts are prep rather than truly part of a state.
+        List<CodeInstruction> prepSection = [];
+        List<int> stateIndices = [];
+        CodeInstruction? jumpDest = null;
+        
+        do
+        {
+            var instruction = codeEnumerator.Current;
+            
+            foreach (var label in instruction.labels)
+            {
+                if (branchSource.LabelStates.TryGetValue(label, out var state))
+                {
+                    BaseLibMain.Logger.Debug($"Found state resume point label {label.Id} for state {state}");
+                    stateIndices.Add(state);
+                    jumpDest = instruction;
+                }
+            }
+            
+            if (jumpDest != null)
+            {
+                BaseLibMain.Logger.VeryDebug("End of state prep");
+                break;
+            }
+                
+            prepSection.Add(instruction);
+
+            /*if (instruction.opcode == OpCodes.Br || instruction.opcode == OpCodes.Br_S)
+            {
+                //Unconditional branch
+                BaseLibMain.Logger.Debug("Found unconditional branch in state, likely contains looping.");
+            }*/
+        } while(codeEnumerator.MoveNext());
+
+        if (stateIndices.Count == 0 || jumpDest == null)
+        {
+            throw new Exception("Failed to find state branches.");
+        }
+
+        if (stateIndices.Count > 1)
+        {
+            BaseLibMain.Logger.Debug("Section is destination of multiple states; should be additional branching section.");
+            var result = BranchingStateSection.Read(context, loadStateSection, codeEnumerator);
+            result.Prep = prepSection;
+            return result;
+        }
+        
+        //Standard single state
+        var stateIndex = stateIndices[0];
+            
+        List<CodeInstruction> stateSection = [..prepSection];
+        HashSet<Label> leaveLabels = [];
+        bool endingState = false;
+
+        do
+        {
+            var instruction = codeEnumerator.Current;
+            
+            if (instruction.opcode == OpCodes.Leave || instruction.opcode == OpCodes.Leave_S)
+            {
+                if (instruction.operand is Label label)
+                {
+                    leaveLabels.Add(label);
+                }
+            }
+            
+            //Check for ending of state
+            if (instruction.opcode == OpCodes.Call && instruction.operand is MethodInfo { Name: "GetResult" } methodInfo 
+                                                   && (methodInfo.DeclaringType?.Name.StartsWith("TaskAwaiter") ?? false))
+            {
+                endingState = true;
+                stateSection.Add(instruction);
+            }
+            else if (endingState) //Last instruction of state
+            {
+                if (instruction.IsStloc() || instruction.opcode == OpCodes.Nop || instruction.opcode == OpCodes.Pop)
+                {
+                    stateSection.Add(instruction);
+                    codeEnumerator.MoveNext();
+                }
+                
+                var state = new StateInfo(stateIndex, stateSection, context.StateField);
+                BaseLibMain.Logger.Debug($"Generated StateInfo for state {stateIndex}");
+                if (state.Index >= context.NextStateIndex)
+                    context.NextStateIndex = state.Index + 1;
+
+                var result = new BranchSection
+                {
+                    State = state,
+                    ResumeInstruction = jumpDest,
+                    LeaveLabels = leaveLabels
+                };
+                
+                if (loadStateSection.AddStateLoading)
+                {
+                    result.State.AddSaveState(context.StateField, loadStateSection.StringDictLocal);
+                }
+                
+                return result;
+            }
+            else
+            {
+                stateSection.Add(instruction);
+            }
+        } while(codeEnumerator.MoveNext());
+
+        throw new Exception($"Failed to find end of state {stateIndex}");
+    }
+
+    public static BranchSection Create(AsyncMethodContext context, LoadStateSection loadSection, EndingSection endingSection,
+        MethodInfo callMethod, IEnumerable<StateParamInfo> loadFields, Label resumeLabel, 
+        AsyncMethodCall.ResultType resultType, string? resultName)
+    {
+        var generator = context.Generator;
+        
+        var awaiterType = typeof(TaskAwaiter);
+        var taskMethodBuilderType = context.BuilderField.FieldType;
+        var valueTypeMachine = context.StateMachineType.IsValueType;
+
+        var returnType = typeof(void);
+        if (callMethod.ReturnType.IsGenericType)
+        {
+            returnType = callMethod.ReturnType.GetGenericArguments()[0];
+            BaseLibMain.Logger.Debug($"Method to call has return type; making generic awaiter type [{returnType}]");
+            awaiterType = typeof(TaskAwaiter<>).MakeGenericType(returnType);
+        }
+        
+        var taskGetAwaiter = callMethod.ReturnType.GetMethod("GetAwaiter");
+        if (taskGetAwaiter == null)
+            throw new Exception($"Failed to get GetAwaiter for type {callMethod.ReturnType}");
+
+        var awaitUnsafe = taskMethodBuilderType.GetMethod("AwaitUnsafeOnCompleted");
+        if (awaitUnsafe == null)
+            throw new Exception($"Failed to get AwaitUnsafeOnCompleted for type {taskMethodBuilderType}");
+        if (awaitUnsafe.IsGenericMethodDefinition)
+        {
+            awaitUnsafe = awaitUnsafe.MakeGenericMethod(awaiterType, context.StateMachineType);
+        }
+        
+        var taskAwaiter = generator.DeclareLocal(awaiterType);
+        var isCompleted = awaiterType.PropertyGetter("IsCompleted");
+        
+        var endingSectionLabel = generator.DefineLabel();
+        
+        //Prep initial method call
+        List<Label> leaveLabels = [];
+        List<CodeInstruction> stateInstructions = [];
+        StateParamInfo? resultParam = null;
+
+        foreach (var loadField in loadFields) //Load fields as parameters for method
+        {
+            if (resultType == AsyncMethodCall.ResultType.Named && loadField.Parameter.Name == resultName)
+            {
+                resultParam = loadField;
+            }
+            loadField.AddLoadInstructions(stateInstructions);
+        }
+
+        if (resultParam != null)
+        {
+            //Validate result param type
+            if (!returnType.IsAssignableTo(resultParam.Parameter.ParameterType))
+            {
+                throw new ArgumentException(
+                    $"Cannot store method result of type {returnType} to parameter {resultParam.Parameter.Name} of type {resultParam.Parameter.ParameterType}");
+            }
+        }
+        
+        //Loaded parameters, now call async method and store awaiter in local
+        stateInstructions.AddRange([
+            new CodeInstruction(OpCodes.Call, callMethod),
+            taskGetAwaiter.CallVirt(),
+            CodeInstruction.StoreLocal(taskAwaiter.LocalIndex),
+            CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true),
+            new CodeInstruction(OpCodes.Call, isCompleted),
+            new CodeInstruction(OpCodes.Brtrue, endingSectionLabel) //If already complete, skip to end
+        ]);
+        
+        //await block; prep for awaiting
+        stateInstructions.AddRange([
+            CodeInstruction.LoadArgument(0),  //load "this" for stfld
+            context.NextStateIndex.LoadConstant(),
+            new CodeInstruction(OpCodes.Call, AsyncMethodCall.StoreStateInDictMethod), //Use external dict for real state
+            new CodeInstruction(OpCodes.Dup),
+            CodeInstruction.LoadLocal(loadSection.StringDictLocal),
+            new CodeInstruction(OpCodes.Call, AsyncMethodCall.StoreDictionaryForStateMethod), //Store string dict
+            new CodeInstruction(OpCodes.Dup),
+            CodeInstruction.StoreLocal(0), //Store state in local 0
+            context.StateField.Stfld(), //and in state field
+        
+            CodeInstruction.LoadLocal(taskAwaiter.LocalIndex), //load awaiter and store in external dict
+            new CodeInstruction(OpCodes.Box, awaiterType),
+            CodeInstruction.LoadLocal(0), //Load generated fake state key
+            AsyncMethodCall.StoreAwaiterMethod.Call()
+        ]);
+        
+        //perform await
+        var retLabel = generator.DefineLabel();
+        leaveLabels.Add(retLabel);
+        endingSection.AwaitAsyncInstruction.WithLabels(retLabel);
+        
+        stateInstructions.AddRange([
+            CodeInstruction.LoadArgument(0), //Get builder and AwaitUnsafeOnCompleted
+            new CodeInstruction(OpCodes.Ldflda, context.BuilderField),
+            CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true),
+            CodeInstruction.LoadArgument(0, !valueTypeMachine),
+            awaitUnsafe.Call(),
+            new CodeInstruction(OpCodes.Leave, retLabel)
+        ]);
+        
+        //Section 3 - restore state
+        var resumeInstruction = new CodeInstruction(OpCodes.Nop).WithLabels(resumeLabel);
+        
+        stateInstructions.AddRange([
+            resumeInstruction,
+            CodeInstruction.LoadLocal(loadSection.StateKeyLocal),
+            AsyncMethodCall.GetAwaiterMethod.Call(),
+            new CodeInstruction(OpCodes.Unbox_Any, awaiterType),
+            CodeInstruction.StoreLocal(taskAwaiter.LocalIndex) //Store in local
+        ]);
+        //Code to reset field that was holding the awaiter, not necessary due to external store
+        //newCode.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true));
+        //newCode.Add(new CodeInstruction(OpCodes.Initobj, awaiterType));
+        
+        //Set state to -1
+        stateInstructions.AddRange([
+            CodeInstruction.LoadArgument(0),
+            (-1).LoadConstant(),
+            new CodeInstruction(OpCodes.Dup),
+            CodeInstruction.StoreLocal(0),
+            context.StateField.Stfld()
+        ]);
+        
+        //Section 4 - get result
+        stateInstructions.Add(new CodeInstruction(OpCodes.Nop).WithLabels(endingSectionLabel));
+        stateInstructions.Add(CodeInstruction.LoadLocal(taskAwaiter.LocalIndex, true));
+        stateInstructions.Add(CodeInstruction.Call(awaiterType, "GetResult"));
+
+        //Can do 3 things with result:
+        //Store (in resultParam or by name)
+        //Return
+        //Ignore
+        switch (resultType)
+        {
+            case AsyncMethodCall.ResultType.Return:
+                var endAsyncUnconditionalLabel = generator.DefineLabel();
+                endingSection.FinishAsyncInstruction.WithLabels(endAsyncUnconditionalLabel);
+                
+                stateInstructions.Add(returnType == typeof(void)
+                    ? new CodeInstruction(OpCodes.Nop)
+                    : CodeInstruction.StoreLocal(1));
+                stateInstructions.Add(new CodeInstruction(OpCodes.Leave, endAsyncUnconditionalLabel));
+                break;
+            case AsyncMethodCall.ResultType.ReturnIf:
+                //Currently a bool on stack.
+                var skipLeaveLabel = generator.DefineLabel();
+                var endAsyncConditionalLabel = generator.DefineLabel();
+                endingSection.FinishAsyncInstruction.WithLabels(endAsyncConditionalLabel);
+                stateInstructions.Add(new CodeInstruction(OpCodes.Brfalse_S, skipLeaveLabel));
+                stateInstructions.Add(new CodeInstruction(OpCodes.Leave, endAsyncConditionalLabel));
+                stateInstructions.Add(new CodeInstruction(OpCodes.Nop).WithLabels(skipLeaveLabel));
+                break;
+            case AsyncMethodCall.ResultType.Named:
+                if (resultParam != null)
+                {
+                    resultParam.AddStoreInstructions(stateInstructions);
+                }
+                else if (resultName != null)
+                {
+                    if (returnType.IsValueType)
+                    {
+                        stateInstructions.Add(new CodeInstruction(OpCodes.Box, returnType));
+                    }
+                    stateInstructions.Add(CodeInstruction.LoadLocal(loadSection.StringDictLocal));
+                    stateInstructions.Add(new CodeInstruction(OpCodes.Ldstr, resultName));
+                    stateInstructions.Add(AsyncMethodCall.StoreNamedMethod.Call());
+                }
+                break;
+            default:
+                //Don't need to keep result.
+                stateInstructions.Add(new CodeInstruction(returnType == typeof(void) ? OpCodes.Nop : OpCodes.Pop));
+                break;
+        }
+
+        return new BranchSection
+        {
+            State = new StateInfo(context.NextStateIndex, stateInstructions, callMethod),
+            ResumeInstruction = resumeInstruction,
+            LeaveLabels = leaveLabels
+        };
+    }
+
+    public required CodeInstruction ResumeInstruction { get; init; }
+
+    public required StateInfo State { get; init; }
+    public required IEnumerable<Label> LeaveLabels { get; init; }
+    
+    public List<CodeInstruction> Code => State.Code;
+    public IEnumerable<StateInfo> AllStates => [State];
+
+    public BranchingStateSection BranchTo(AsyncMethodContext context, StateInfo targetState, ILGenerator generator, out Label resumeLabel)
+    {
+        throw new InvalidOperationException("Non-branching state section cannot perform branching.");
+    }
+}

--- a/Utils/Patching/AsyncMethodSections/BranchingStateSection.cs
+++ b/Utils/Patching/AsyncMethodSections/BranchingStateSection.cs
@@ -1,0 +1,237 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using BaseLib.Extensions;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal class BranchingStateSection : IAsyncStateSection
+{
+    public static BranchingStateSection Read(AsyncMethodContext context, LoadStateSection loadStateSection, IEnumerator<CodeInstruction> codeEnumerator)
+    {
+        BaseLibMain.Logger.Debug("Starting branching section");
+        List<CodeInstruction> branchSection = [];
+        
+        //First, analyze initial branching to determine starts of each state branch.
+        //If branch is conditional, determine required state. If conditional branch destination is an unconditional branch, update that state's position.
+        Dictionary<int, Label> stateLabels = [];
+        int? checkState = null;
+        int stateOffset = 0;
+        
+        bool exitLoop = false;
+
+        do
+        {
+            var instruction = codeEnumerator.Current;
+
+            if (branchSection.Count == 0 || instruction.opcode == OpCodes.Ldloc_0)
+            {
+                branchSection.Add(instruction);
+            }
+            else if (instruction.opcode == OpCodes.Switch)
+            {
+                var labelArr = (Label[]) instruction.operand;
+                for (int i = 0; i < labelArr.Length; ++i)
+                {
+                    stateLabels[i + stateOffset] = labelArr[i];
+                }
+                branchSection.Add(instruction);
+
+                codeEnumerator.MoveNext();
+                break;
+            }
+            else if (instruction.TryGetIntValue(out var loadedConst))
+            {
+                checkState = loadedConst;
+                branchSection.Add(instruction);
+            }
+            else
+            {
+                switch (instruction.opcode.Value)
+                {
+                    case (int) OpCodeValues.Nop:
+                        if (instruction.labels.Count > 0)
+                        {
+                            exitLoop = true;
+                        }
+                        break;
+                    case (int) OpCodeValues.Sub:
+                        if (checkState == null)
+                        {
+                            BaseLibMain.Logger.Warn("Failed to evaluate sub, checkState null");
+                            break;
+                        }
+
+                        if (stateOffset != 0)
+                        {
+                            BaseLibMain.Logger.Warn("Failed to process sub, stateOffset already set");
+                            break;
+                        }
+
+                        stateOffset = checkState.Value;
+                        checkState = null;
+                        BaseLibMain.Logger.Debug($"Branching section uses sub offset of {stateOffset}");
+                        break;
+                    case (int) OpCodeValues.Brfalse_S:
+                    case (int) OpCodeValues.Brfalse: //Branch if current state == 0
+                        stateLabels[0] = (Label)instruction.operand;
+                        //BaseLibMain.Logger.Info($"State 0 dest {stateLabels[0].Id}");
+                        break;
+                    case (int) OpCodeValues.Brtrue_S:
+                    case (int) OpCodeValues.Brtrue: //What
+                        BaseLibMain.Logger.Warn("Unexpected Brtrue in jump section of state machine");
+                        break;
+                    case (int) OpCodeValues.Beq_S:
+                    case (int) OpCodeValues.Beq: //Branch if current state == ?
+                        if (checkState == null)
+                        {
+                            BaseLibMain.Logger.Warn("Failed to evaluate beq, checkState null");
+                            break;
+                        }
+                        stateLabels[checkState.Value] = (Label)instruction.operand;
+                        //BaseLibMain.Logger.Info($"State {checkState.Value} dest {stateLabels[checkState.Value].Id}");
+                        break;
+                    case (int) OpCodeValues.Br_S:
+                    case (int) OpCodeValues.Br: //Unconditional branch. State -1 or intermediate jump.
+                        var opLabel = (Label)instruction.operand;
+                        foreach (var entry in stateLabels)
+                        {
+                            foreach (var label in instruction.labels)
+                            {
+                                if (entry.Value == label)
+                                {
+                                    stateLabels[entry.Key] = opLabel;
+                                    //BaseLibMain.Logger.Info($"State {entry.Key} dest {stateLabels[entry.Key].Id}");
+                                    break;
+                                }
+                            }
+                        }
+                        break;
+                    default:
+                        BaseLibMain.Logger.Debug($"Found end of branching section");
+                        exitLoop = true;
+                        break;
+                }
+
+                if (!exitLoop)
+                    branchSection.Add(instruction);
+                else
+                    break; //Skip MoveNext
+            }
+        } while (codeEnumerator.MoveNext());
+        
+        Dictionary<Label, int> labelStates = [];
+        foreach (var entry in stateLabels)
+        {
+            labelStates[entry.Value] = entry.Key;
+        }
+
+        var branchingStateSection = new BranchingStateSection()
+        {
+            Branching = branchSection,
+            LabelStates = labelStates
+        };
+        
+        //Now check branches found
+        while (stateLabels.Count > 0)
+        {
+            var newSection = BranchSection.Read(context, loadStateSection, branchingStateSection, codeEnumerator);
+            foreach (var state in newSection.AllStates)
+            {
+                stateLabels.Remove(state.Index);
+            }
+
+            branchingStateSection.Sections.Add(newSection);
+        }
+
+        return branchingStateSection;
+    }
+
+    public required Dictionary<Label, int> LabelStates { get; init; }
+
+    public List<CodeInstruction> Prep { get; set; } = [];
+    public required List<CodeInstruction> Branching { get; set; }
+    public readonly List<IAsyncStateSection> Sections = [];
+    
+    public CodeInstruction ResumeInstruction => Branching.First();
+
+    public List<CodeInstruction> Code =>
+    [
+        ..Prep,
+        ..Branching,
+        ..Sections.SelectMany(section => section.Code)
+    ];
+
+    public IEnumerable<StateInfo> AllStates => Sections.SelectMany(section => section.AllStates);
+    public IEnumerable<Label> LeaveLabels => Sections.SelectMany(section => section.LeaveLabels);
+
+
+    /// <summary>
+    /// Generates code instructions to branch to a new state labeled with resumeLabel.
+    /// </summary>
+    public BranchingStateSection BranchTo(AsyncMethodContext context, StateInfo targetState, ILGenerator generator, out Label resumeLabel)
+    {
+        foreach (var branch in Sections)
+        {
+            if (!branch.AllStates.Contains(targetState))
+                continue;
+            
+            resumeLabel = generator.DefineLabel();
+            BaseLibMain.Logger.Debug($"Generating branch instruction in branching section using label {resumeLabel.Id}");
+
+            for (var i = 0; i < Branching.Count; ++i)
+            {
+                var ci = Branching[i];
+                if (ci.blocks.Count == 0) continue;
+                
+                if (i == 0)
+                {
+                    Branching = [
+                        CodeInstruction.LoadLocal(0).MoveLabelsFrom(Branching[0]).MoveBlocksFrom(Branching[0]),
+                        context.NextStateIndex.LoadConstant(),
+                        new CodeInstruction(OpCodes.Beq, resumeLabel),
+                        ..Branching
+                    ];
+                }
+                else
+                {
+                    Branching = [
+                        ..Branching.Take(i),
+                        CodeInstruction.LoadLocal(0).MoveBlocksFrom(Branching[i]),
+                        context.NextStateIndex.LoadConstant(),
+                        new CodeInstruction(OpCodes.Beq, resumeLabel),
+                        ..Branching.Skip(i)
+                    ];
+                }
+                break;
+            }
+            
+            
+            if (branch is BranchingStateSection branchingBranch)
+            {
+                branchingBranch.ResumeInstruction.WithLabels(resumeLabel);
+                var innerBranch = branchingBranch.BranchTo(context, targetState, generator, out resumeLabel);
+                return innerBranch;
+            }
+            
+            return this;
+        }
+
+        throw new InvalidOperationException("Failed to find target state in branching state section.");
+    }
+
+    public void InsertState(AsyncMethodContext context, LoadStateSection loadSection, EndingSection endingSection, 
+        bool before, StateInfo targetState, MethodInfo callMethod, 
+        List<StateParamInfo> methodCallParams, Label resumeLabel, AsyncMethodCall.ResultType resultType, string? resultName)
+    {
+        int insertIndex = Sections.FindIndex(section => section is BranchSection branchSection && branchSection.State == targetState);
+        if (insertIndex < 0)
+            throw new InvalidOperationException("Failed to find target state in branching state section.");
+
+        if (!before)
+            ++insertIndex;
+        
+        Sections.Insert(insertIndex, BranchSection.Create(context, loadSection, endingSection, 
+            callMethod, methodCallParams, resumeLabel, resultType, resultName));
+    }
+}

--- a/Utils/Patching/AsyncMethodSections/EndingSection.cs
+++ b/Utils/Patching/AsyncMethodSections/EndingSection.cs
@@ -1,0 +1,90 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal class EndingSection : IAsyncMethodSection
+{
+    public static EndingSection Read(IAsyncStateSection mainSection, IEnumerator<CodeInstruction> codeEnumerator)
+    {
+        //Analyze ending section
+        Type? returnType = null;
+        CodeInstruction? retValInstruction = null;
+        CodeInstruction? directRetInstruction = null;
+
+        List<Label> leaveLabels = [..mainSection.LeaveLabels];
+        
+        List<CodeInstruction> endingSection = [];
+        do
+        {
+            var instruction = codeEnumerator.Current;
+            endingSection.Add(instruction);
+            
+            //When code after last async method call and no conditional early returns that will be in a state
+            if (instruction.opcode == OpCodes.Leave || instruction.opcode == OpCodes.Leave_S)
+            {
+                if (instruction.operand is Label label)
+                {
+                    leaveLabels.Add(label);
+                }
+            }
+            
+            foreach (var label in instruction.labels)
+            {
+                if (!leaveLabels.Remove(label)) continue;
+                
+                //This instruction is left to from a state.
+                if (instruction.opcode == OpCodes.Ret)
+                {
+                    directRetInstruction ??= instruction;
+                }
+                else
+                {
+                    retValInstruction ??= instruction;
+                }
+            }
+            
+            if (returnType != null || instruction.opcode != OpCodes.Call
+                                   || instruction.operand is not MethodInfo { Name: "SetResult" } info) continue;
+            
+            var declaringType = info.DeclaringType;
+            if (declaringType == null) continue;
+
+            if (declaringType == typeof(AsyncTaskMethodBuilder)
+                || declaringType == typeof(AsyncValueTaskMethodBuilder))
+            {
+                continue;
+            }
+            if (declaringType.IsConstructedGenericType 
+                && (declaringType.GetGenericTypeDefinition() == typeof(AsyncTaskMethodBuilder<>)
+                    || declaringType.GetGenericTypeDefinition() == typeof(AsyncValueTaskMethodBuilder<>)))
+            {
+                returnType = declaringType.GenericTypeArguments[0];
+            }
+        } while (codeEnumerator.MoveNext());
+
+        if (retValInstruction == null)
+            throw new Exception($"Failed to find instruction to jump to when done with async method;\n" +
+                                $"CODE:\n{endingSection.Join(instruction => instruction.ToString(),"\n")}");
+        if (directRetInstruction == null)
+            throw new Exception("Failed to find instruction to jump to when awaiting;\n" +
+                                $"CODE:\n{endingSection.Join(instruction => instruction.ToString(),"\n")}");
+
+        return new EndingSection
+        {
+            Code = endingSection,
+            ReturnType = returnType,
+            FinishAsyncInstruction = retValInstruction,
+            AwaitAsyncInstruction = directRetInstruction
+        };
+    }
+
+    
+    public required List<CodeInstruction> Code { get; init; }
+    public IEnumerable<StateInfo> AllStates => [];
+    public required Type? ReturnType { get; init; }
+    public required CodeInstruction AwaitAsyncInstruction { get; init; }
+    public required CodeInstruction FinishAsyncInstruction { get; init; }
+}

--- a/Utils/Patching/AsyncMethodSections/IAsyncMethodSection.cs
+++ b/Utils/Patching/AsyncMethodSections/IAsyncMethodSection.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal interface IAsyncMethodSection
+{
+    List<CodeInstruction> Code { get; }
+    
+    IEnumerable<StateInfo> AllStates { get; }
+}
+
+internal interface IAsyncStateSection : IAsyncMethodSection
+{
+    IEnumerable<Label> LeaveLabels { get; }
+    CodeInstruction ResumeInstruction { get; }
+
+    BranchingStateSection BranchTo(AsyncMethodContext context, StateInfo targetState, 
+        ILGenerator generator, out Label resumeLabel);
+}

--- a/Utils/Patching/AsyncMethodSections/LoadStateSection.cs
+++ b/Utils/Patching/AsyncMethodSections/LoadStateSection.cs
@@ -1,0 +1,122 @@
+﻿using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal class LoadStateSection : IAsyncMethodSection
+{
+    /// <summary>
+    /// Reads a LoadStateSection using an enumerator that is already ready to read.
+    /// </summary>
+    public static LoadStateSection Read(AsyncMethodContext context, IEnumerator<CodeInstruction> codeEnumerator)
+    {
+        bool loadsFoundStateField = false;
+        bool loadsStateFromDict = false;
+        bool loadedDictionary = false;
+        int? stateKeyLocalIndex = null;
+        int? stringDictLocalIndex = null;
+        
+        List<CodeInstruction> loadStateSection = [];
+        do
+        {
+            var instruction = codeEnumerator.Current;
+            if (instruction.HasBlock(ExceptionBlockType.BeginExceptionBlock))
+            {
+                break;
+            }
+
+            loadStateSection.Add(instruction);
+            if (instruction.LoadsField(context.StateField))
+            {
+                loadsFoundStateField = true;
+            }
+
+            if (!loadsStateFromDict)
+            {
+                if (instruction.Calls(AsyncMethodCall.LoadStateFromDictMethod))
+                {
+                    loadsStateFromDict = true;
+                }
+            }
+            else
+            {
+                if (stateKeyLocalIndex == null && instruction.IsStloc())
+                {
+                    stateKeyLocalIndex = instruction.LocalIndex();
+                }
+
+                if (!loadedDictionary)
+                {
+                    if (instruction.Calls(AsyncMethodCall.LoadDictionaryForStateMethod))
+                    {
+                        loadedDictionary = true;
+                    }
+                }
+                else
+                {
+                    if (stringDictLocalIndex == null && instruction.IsStloc())
+                    {
+                        stringDictLocalIndex = instruction.LocalIndex();
+                    }
+                }
+            }
+        }
+        while (codeEnumerator.MoveNext());
+
+        if (!loadsFoundStateField)
+        {
+            throw new ArgumentException(
+                $"MoveNext does not load found state field {context.StateField}; failed to set up AsyncMethodCall properly");
+        }
+
+        if (!loadsStateFromDict)
+        {
+            BaseLibMain.Logger.Debug("Setting up external state");
+            var stateKeyLocal = context.Generator.DeclareLocal(typeof(int));
+            var stringDictLocal = context.Generator.DeclareLocal(typeof(Dictionary<string, object>));
+            
+            stateKeyLocalIndex = stateKeyLocal.LocalIndex;
+            stringDictLocalIndex = stringDictLocal.LocalIndex;
+            
+            loadStateSection =
+            [
+                CodeInstruction.LoadArgument(0), //One for ldfld, one for stfld
+                CodeInstruction.LoadArgument(0),
+                new CodeInstruction(OpCodes.Ldfld, context.StateField),
+                new CodeInstruction(OpCodes.Dup),
+                CodeInstruction.StoreLocal(stateKeyLocalIndex.Value),
+                new CodeInstruction(OpCodes.Call, AsyncMethodCall.LoadStateFromDictMethod),
+                new CodeInstruction(OpCodes.Stfld, context.StateField),
+                CodeInstruction.LoadLocal(stateKeyLocalIndex.Value),
+                new CodeInstruction(OpCodes.Call, AsyncMethodCall.LoadDictionaryForStateMethod),
+                CodeInstruction.StoreLocal(stringDictLocalIndex.Value),
+                ..loadStateSection
+            ];
+        }
+        else if (stateKeyLocalIndex == null) //Loads state from dict but did not find local in which it is stored
+        {
+            throw new ArgumentException(
+                "Failed to find local used to hold temporary state key.");
+        }
+        else if (stringDictLocalIndex == null)
+        {
+            throw new ArgumentException(
+                "Failed to find local used to hold extra saved values.");
+        }
+
+        return new LoadStateSection
+        {
+            Code = loadStateSection,
+            AddStateLoading = !loadsStateFromDict,
+            StateKeyLocal = stateKeyLocalIndex.Value,
+            StringDictLocal = stringDictLocalIndex.Value
+        };
+    }
+
+    public required List<CodeInstruction> Code { get; init; }
+    public required bool AddStateLoading { get; init; }
+    public required int StringDictLocal { get; init; }
+    public required int StateKeyLocal { get; init; }
+    
+    public IEnumerable<StateInfo> AllStates => [];
+}

--- a/Utils/Patching/AsyncMethodSections/LoadStateSection.cs
+++ b/Utils/Patching/AsyncMethodSections/LoadStateSection.cs
@@ -10,11 +10,10 @@ internal class LoadStateSection : IAsyncMethodSection
     /// </summary>
     public static LoadStateSection Read(AsyncMethodContext context, IEnumerator<CodeInstruction> codeEnumerator)
     {
-        bool loadsFoundStateField = false;
-        bool loadsStateFromDict = false;
-        bool loadedDictionary = false;
-        int? stateKeyLocalIndex = null;
-        int? stringDictLocalIndex = null;
+        var loadsFoundStateField = false;
+        var loadsStateFromDict = false;
+        int stateKeyLocalIndex = -1;
+        int stringDictLocalIndex = -1;
         
         List<CodeInstruction> loadStateSection = [];
         do
@@ -31,34 +30,9 @@ internal class LoadStateSection : IAsyncMethodSection
                 loadsFoundStateField = true;
             }
 
-            if (!loadsStateFromDict)
+            if (instruction.Calls(AsyncMethodCall.LoadStateFromDictMethod))
             {
-                if (instruction.Calls(AsyncMethodCall.LoadStateFromDictMethod))
-                {
-                    loadsStateFromDict = true;
-                }
-            }
-            else
-            {
-                if (stateKeyLocalIndex == null && instruction.IsStloc())
-                {
-                    stateKeyLocalIndex = instruction.LocalIndex();
-                }
-
-                if (!loadedDictionary)
-                {
-                    if (instruction.Calls(AsyncMethodCall.LoadDictionaryForStateMethod))
-                    {
-                        loadedDictionary = true;
-                    }
-                }
-                else
-                {
-                    if (stringDictLocalIndex == null && instruction.IsStloc())
-                    {
-                        stringDictLocalIndex = instruction.LocalIndex();
-                    }
-                }
+                loadsStateFromDict = true;
             }
         }
         while (codeEnumerator.MoveNext());
@@ -84,21 +58,41 @@ internal class LoadStateSection : IAsyncMethodSection
                 CodeInstruction.LoadArgument(0),
                 new CodeInstruction(OpCodes.Ldfld, context.StateField),
                 new CodeInstruction(OpCodes.Dup),
-                CodeInstruction.StoreLocal(stateKeyLocalIndex.Value),
+                CodeInstruction.StoreLocal(stateKeyLocalIndex),
                 new CodeInstruction(OpCodes.Call, AsyncMethodCall.LoadStateFromDictMethod),
                 new CodeInstruction(OpCodes.Stfld, context.StateField),
-                CodeInstruction.LoadLocal(stateKeyLocalIndex.Value),
+                CodeInstruction.LoadLocal(stateKeyLocalIndex),
                 new CodeInstruction(OpCodes.Call, AsyncMethodCall.LoadDictionaryForStateMethod),
-                CodeInstruction.StoreLocal(stringDictLocalIndex.Value),
+                CodeInstruction.StoreLocal(stringDictLocalIndex),
                 ..loadStateSection
             ];
         }
-        else if (stateKeyLocalIndex == null) //Loads state from dict but did not find local in which it is stored
+        else
+        {
+            BaseLibMain.Logger.Debug("Checking for external state loading");
+
+            new InstructionPatcher(loadStateSection)
+                .TryMatch(new InstructionMatcher()
+                    .ldfld(context.StateField)
+                    .dup()
+                    .stloc_any()
+                )
+                ?.Step(-1)
+                .GetIndexOperand(out stateKeyLocalIndex)
+                .TryMatch(new InstructionMatcher()
+                    .call(AsyncMethodCall.LoadDictionaryForStateMethod)
+                    .stloc_any()
+                )
+                ?.Step(-1)
+                .GetIndexOperand(out stringDictLocalIndex);
+        }
+        
+        if (stateKeyLocalIndex == -1) //Loads state from dict but did not find local in which it is stored
         {
             throw new ArgumentException(
                 "Failed to find local used to hold temporary state key.");
         }
-        else if (stringDictLocalIndex == null)
+        if (stringDictLocalIndex == -1)
         {
             throw new ArgumentException(
                 "Failed to find local used to hold extra saved values.");
@@ -108,8 +102,8 @@ internal class LoadStateSection : IAsyncMethodSection
         {
             Code = loadStateSection,
             AddStateLoading = !loadsStateFromDict,
-            StateKeyLocal = stateKeyLocalIndex.Value,
-            StringDictLocal = stringDictLocalIndex.Value
+            StateKeyLocal = stateKeyLocalIndex,
+            StringDictLocal = stringDictLocalIndex
         };
     }
 

--- a/Utils/Patching/AsyncMethodSections/MoveNextSection.cs
+++ b/Utils/Patching/AsyncMethodSections/MoveNextSection.cs
@@ -1,0 +1,49 @@
+﻿using System.Reflection;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal class MoveNextSection : IAsyncMethodSection
+{
+    /// <summary>
+    /// Reads a new MoveNextSection using an enumerator that is already ready to read.
+    /// </summary>
+    public static MoveNextSection Read(AsyncMethodContext context, IEnumerator<CodeInstruction> codeEnumerator)
+    {
+        var loadStateSection = LoadStateSection.Read(context, codeEnumerator);
+        var mainSection = BranchingStateSection.Read(context, loadStateSection, codeEnumerator);
+        var endingSection = EndingSection.Read(mainSection, codeEnumerator);
+        
+        return new MoveNextSection
+        {
+            LoadSection = loadStateSection,
+            MainSection = mainSection,
+            EndingSection = endingSection
+        };
+    }
+    
+    public required LoadStateSection LoadSection { get; internal init; }
+    public required IAsyncStateSection MainSection { get; internal init; }
+    public required EndingSection EndingSection { get; internal init; }
+
+    public List<CodeInstruction> Code =>
+    [
+        ..LoadSection.Code,
+        ..MainSection.Code,
+        ..EndingSection.Code
+    ];
+
+    public IEnumerable<StateInfo> AllStates => MainSection.AllStates;
+
+    public void InsertState(AsyncMethodContext context, bool before, StateInfo targetState,
+        MethodInfo callMethod, List<StateParamInfo> methodCallParams,
+        AsyncMethodCall.ResultType resultType, string? resultName)
+    {
+        var generator = context.Generator;
+
+        var branchParent = MainSection.BranchTo(context, targetState, generator, out var resumeLabel);
+
+        branchParent.InsertState(context, LoadSection, EndingSection,
+            before, targetState,  callMethod, methodCallParams, resumeLabel, resultType, resultName);
+    }
+}

--- a/Utils/Patching/AsyncMethodSections/StateInfo.cs
+++ b/Utils/Patching/AsyncMethodSections/StateInfo.cs
@@ -1,0 +1,67 @@
+﻿using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+
+internal class StateInfo //, MethodBase stateMethod, int indexLoadIndex)
+{
+    public int Index { get; }
+    public List<CodeInstruction> Code { get; private set; }
+    public MethodInfo? StateMethod { get; }
+    
+    public StateInfo(int index, List<CodeInstruction> code, FieldInfo stateField)
+    {
+        Index = index;
+        Code = code;
+
+        StateMethod = AnalyzeCode(stateField, Index, Code);
+    }
+    public StateInfo(int index, List<CodeInstruction> code, MethodInfo stateMethod)
+    {
+        Index = index;
+        Code = code;
+
+        StateMethod = stateMethod;
+    }
+
+    private static MethodInfo? AnalyzeCode(FieldInfo stateField, int stateIndex, List<CodeInstruction> code)
+    {
+        var storeStateMatcher = new InstructionMatcher().stfld(stateField);
+
+        InstructionPatcher reader = new(code);
+    
+        bool[] matched = [true];
+        reader.Match(_ => matched[0] = false, AsyncMethodCall.StateAwaitMatcher);
+        if (!matched[0])
+        {
+            BaseLibMain.Logger.Info($"CODE:\n{code.Join(instruction => instruction.ToString(), "\n")}");
+            throw new InvalidOperationException($"Failed to find state awaiter for state {stateIndex}");
+        }
+
+        reader
+            .Step(-2).GetOperand(out var operand) //Get method called to get awaited task
+            .Step(3)
+            .Match(storeStateMatcher); //Move to next state store (occurs when awaited task does not end immediately)
+        
+        return operand as MethodInfo;
+    }
+
+    public void AddSaveState(FieldInfo stateField, int stringDictLocal)
+    {
+        Code = new InstructionPatcher(Code)
+            .Match(AsyncMethodCall.StateAwaitMatcher)
+            .Match(new InstructionMatcher()
+                .dup()
+                .stloc_0()
+                .stfld(stateField))
+            .Step(-3)
+            .Insert([
+                new CodeInstruction(OpCodes.Call, AsyncMethodCall.StoreStateInDictMethod), //Replace state with temp state key
+                new CodeInstruction(OpCodes.Dup), //Extra copy of temp state key
+                CodeInstruction.LoadLocal(stringDictLocal),
+                new CodeInstruction(OpCodes.Call, AsyncMethodCall.StoreDictionaryForStateMethod)
+            ]);
+    }
+}

--- a/Utils/Patching/AsyncMethodSections/StateParamInfo.cs
+++ b/Utils/Patching/AsyncMethodSections/StateParamInfo.cs
@@ -1,0 +1,9 @@
+﻿using System.Reflection;
+using HarmonyLib;
+
+namespace BaseLib.Utils.Patching.AsyncMethodSections;
+
+internal record StateParamInfo(
+    ParameterInfo Parameter,
+    Action<List<CodeInstruction>> AddLoadInstructions,
+    Action<List<CodeInstruction>> AddStoreInstructions);

--- a/Utils/Patching/InstructionPatcher.cs
+++ b/Utils/Patching/InstructionPatcher.cs
@@ -84,7 +84,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <exception cref="Exception"></exception>
     public InstructionPatcher Step(int amt = 1)
     {
-        if (_index < 0) throw new Exception("Attempted to Step without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Step without any match found");
 
         _index += amt;
 
@@ -94,11 +94,23 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     }
 
     /// <summary>
+    /// Adds a label to the current instruction.
+    /// </summary>
+    public InstructionPatcher AddLabel(ILGenerator generator, out Label label)
+    {
+        if (_index < 0) throw new InvalidOperationException("Attempted to AddLabel without any match found");
+
+        label = generator.DefineLabel();
+        _code[_index].WithLabels(label);
+        return this;
+    }
+
+    /// <summary>
     /// Gets all labels attached to the current instruction.
     /// </summary>
     public InstructionPatcher GetLabels(out List<Label> labels)
     {
-        if (_index < 0) throw new Exception("Attempted to GetLabels without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetLabels without any match found");
 
         labels = _code[_index].labels;
 
@@ -122,7 +134,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// </summary>
     public InstructionPatcher TakeLabels(out List<Label> labels)
     {
-        if (_index < 0) throw new Exception("Attempted to GetLabels without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetLabels without any match found");
 
         labels = _code[_index].ExtractLabels();
 
@@ -144,23 +156,28 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <summary>
     /// Gets a label used as the operand of the current instruction.
     /// </summary>
-    /// <param name="label"></param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
     public InstructionPatcher GetOperandLabel(out Label label)
     {
-        if (_index < 0) throw new Exception("Attempted to GetOperandLabel without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetOperandLabel without any match found");
         if (_code[_index].operand is Label result)
         {
             label = result;
             return this;
         }
-        throw new Exception($"Code instruction {_code[_index].ToString()} does not have a Label parameter");
+        throw new InvalidOperationException($"Code instruction {_code[_index].ToString()} does not have a Label parameter");
+    }
+
+    public InstructionPatcher GetInstruction(out CodeInstruction instruction)
+    {
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetInstruction without any match found");
+        instruction = _code[_index];
+        Log.Add($"Got instruction [{instruction}]");
+        return this;
     }
 
     public InstructionPatcher GetOperand(out object operand)
     {
-        if (_index < 0) throw new Exception("Attempted to GetOperand without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetOperand without any match found");
         operand = _code[_index].operand;
         Log.Add($"Got operand [{operand?.GetType().FullName}]{operand}");
         return this;
@@ -168,7 +185,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     
     public InstructionPatcher GetIndexOperand(out int operand)
     {
-        if (_index < 0) throw new Exception("Attempted to GetOperand without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to GetOperand without any match found");
         CodeInstruction instruction = _code[_index];
         switch ((int) instruction.opcode.Value)
         {
@@ -208,7 +225,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
                 }
                 break;
             default:
-                throw new Exception($"Unsupported opcode for GetIndexOperand: {instruction.opcode}");
+                throw new InvalidOperationException($"Unsupported opcode for GetIndexOperand: {instruction.opcode}");
         }
         return this;
     }
@@ -216,7 +233,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     public InstructionPatcher TryGetIntValue(out int? val)
     {
         val = null;
-        if (_index < 0) throw new Exception("Attempted to TryGetIntValue without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to TryGetIntValue without any match found");
         
         if (_code[_index].TryGetIntValue(out var result))
         {
@@ -230,12 +247,9 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// Replaces a match of CodeInstructions. Note that if this removes a labeled instruction this can cause issues.
     /// Preserving labels must be done manually.
     /// </summary>
-    /// <param name="replacement"></param>
-    /// <returns></returns>
-    /// <exception cref="Exception"></exception>
     public InstructionPatcher ReplaceLastMatch(IEnumerable<CodeInstruction> replacement)
     {
-        if (_lastMatchStart < 0) throw new Exception("Attempted to ReplaceLastMatch without any match found");
+        if (_lastMatchStart < 0) throw new InvalidOperationException("Attempted to ReplaceLastMatch without any match found");
 
         int i = 0;
         foreach (CodeInstruction instruction in replacement)
@@ -266,9 +280,12 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
         return this;
     }
 
+    /// <summary>
+    /// Replaces the current instruction with another.
+    /// </summary>
     public InstructionPatcher Replace(CodeInstruction replacement, bool keepLabels = true)
     {
-        if (_index < 0) throw new Exception("Attempted to Replace without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Replace without any match found");
 
         if (keepLabels)
         {
@@ -282,7 +299,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
 
     public InstructionPatcher IncrementIntPush()
     {
-        if (_index < 0) throw new Exception("Attempted to Replace without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Replace without any match found");
 
         switch (_code[_index].opcode.Value)
         {
@@ -305,51 +322,37 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
             case 0x1d: //7
                 return Replace(new CodeInstruction(OpCodes.Ldc_I4_8));
             case 0x1e: //8
-                throw new Exception("Instruction " + _code[_index] + " cannot be incremented"); //maybe later support arbitrary int
+                return Replace(new CodeInstruction(OpCodes.Ldc_I4_S, (sbyte)9));
+            case 0x1f: //I4_S
+                if (_code[_index].TryGetIntValue(out var byteResult))
+                {
+                    byteResult += 1;
+                    if (byteResult > sbyte.MaxValue)
+                    {
+                        return Replace(new CodeInstruction(OpCodes.Ldc_I4, byteResult));
+                    }
+                    else
+                    {
+                        return Replace(new CodeInstruction(OpCodes.Ldc_I4_S, (sbyte)byteResult));
+                    }
+                }
+                throw new InvalidOperationException("Failed to determine integer value of " + _code[_index] + " to incremented");
+            case 0x20: //I4
+                if (_code[_index].TryGetIntValue(out var intResult))
+                {
+                    return Replace(new CodeInstruction(OpCodes.Ldc_I4, intResult + 1));
+                }
+                throw new InvalidOperationException("Failed to determine integer value of " + _code[_index] + " to incremented");
             default:
-                throw new Exception("Instruction " + _code[_index] + " is not an int push instruction that can be incremented");
+                throw new InvalidOperationException("Instruction " + _code[_index] + " is not an int push instruction that can be incremented");
         }
     }
     public InstructionPatcher IncrementIntPush(out CodeInstruction replacedPush)
     {
-        if (_index < 0) throw new Exception("Attempted to Replace without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Replace without any match found");
 
-        switch (_code[_index].opcode.Value)
-        {
-            case 0x15: //m1, -1
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_M1);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_0));
-            case 0x16: //0
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_0);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_1));
-            case 0x17: //1
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_1);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_2));
-            case 0x18: //2
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_2);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_3));
-            case 0x19: //3
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_3);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_4));
-            case 0x1a: //4
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_4);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_5));
-            case 0x1b: //5
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_5);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_6));
-            case 0x1c: //6
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_6);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_7));
-            case 0x1d: //7
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_7);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_8));
-            case 0x1e: //8
-                replacedPush = new CodeInstruction(OpCodes.Ldc_I4_8);
-                return Replace(new CodeInstruction(OpCodes.Ldc_I4_S, (sbyte)9));
-            //throw new Exception("Instruction " + code[index] + " cannot be incremented"); //maybe later support arbitrary int
-            default:
-                throw new Exception("Instruction " + _code[_index] + " is not an int push instruction that can be incremented");
-        }
+        replacedPush = _code[_index];
+        return IncrementIntPush();
     }
 
     /// <summary>
@@ -360,7 +363,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <exception cref="Exception"></exception>
     public InstructionPatcher Insert(CodeInstruction instruction)
     {
-        if (_index < 0) throw new Exception("Attempted to Insert without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Insert without any match found");
 
         _code.Insert(_index, instruction);
         ++_index;
@@ -378,7 +381,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <exception cref="Exception"></exception>
     public InstructionPatcher Insert(IEnumerable<CodeInstruction> insert)
     {
-        if (_index < 0) throw new Exception("Attempted to Insert without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to Insert without any match found");
 
         var codeInstructions = insert as CodeInstruction[] ?? insert.ToArray();
         _code.InsertRange(_index, codeInstructions);
@@ -397,7 +400,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <exception cref="Exception"></exception>
     public InstructionPatcher InsertBeforeMatch(IEnumerable<CodeInstruction> insert)
     {
-        if (_index < 0 || _lastMatchStart < 0) throw new Exception("Attempted to Insert without any match found");
+        if (_index < 0 || _lastMatchStart < 0) throw new InvalidOperationException("Attempted to Insert without any match found");
 
         _index = _lastMatchStart;
         _lastMatchStart = -1;
@@ -413,7 +416,7 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
 
     public InstructionPatcher CopyMatch(out List<CodeInstruction> match)
     {
-        if (_index < 0) throw new Exception("Attempted to CopyMatch without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to CopyMatch without any match found");
 
         match = _code.GetRange(_lastMatchStart, _index - _lastMatchStart).Select(instruction => instruction.Clone()).ToList();
         
@@ -435,10 +438,10 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// <exception cref="Exception"></exception>
     public InstructionPatcher InsertCopy(int startOffset, int copyLength)
     {
-        if (_index < 0) throw new Exception("Attempted to InsertCopy without any match found");
+        if (_index < 0) throw new InvalidOperationException("Attempted to InsertCopy without any match found");
 
         int startIndex = _index + startOffset;
-        if (startIndex < 0) throw new Exception($"startIndex of InsertCopy less than 0 ({startIndex})");
+        if (startIndex < 0) throw new InvalidOperationException($"startIndex of InsertCopy less than 0 ({startIndex})");
 
         List<CodeInstruction> copy = [];
         for (int i = 0; i < copyLength; ++i)

--- a/Utils/Patching/InstructionPatcher.cs
+++ b/Utils/Patching/InstructionPatcher.cs
@@ -40,9 +40,6 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
     /// After matching is complete, position is on the code instruction following the last match.
     /// If a match is not found, onFailMatch is called. By default, this will throw an exception.
     /// </summary>
-    /// <param name="onFailMatch"></param>
-    /// <param name="matchers"></param>
-    /// <returns></returns>
     public InstructionPatcher Match(Action<IMatcher[]> onFailMatch, params IMatcher[] matchers)
     {
         if (_index < 0) _index = 0;
@@ -57,6 +54,27 @@ public class InstructionPatcher(IEnumerable<CodeInstruction> instructions)
 
         Log.Add("Found end of match at " + _index + "; last match starts at " + _lastMatchStart);
 
+        return this;
+    }
+
+    /// <summary>
+    /// Iterates over given matchers and attempts to match each in order.
+    /// After matching is complete, position is on the code instruction following the last match.
+    /// If a match is not found, null will be returned, skipping operations chained with the ?. operator.
+    /// </summary>
+    public InstructionPatcher? TryMatch(params IMatcher[] matchers)
+    {
+        if (_index < 0) _index = 0;
+        foreach (IMatcher matcher in matchers)
+        {
+            if (!matcher.Match(Log, _code, _index, out _lastMatchStart, out _index))
+            {
+                Log.Add("TryMatch failed");
+                return null;
+            }
+        }
+
+        Log.Add("Found end of match at " + _index + "; last match starts at " + _lastMatchStart);
         return this;
     }
 

--- a/Utils/TooltipSource.cs
+++ b/Utils/TooltipSource.cs
@@ -23,7 +23,7 @@ public class TooltipSource
     {
         if (t.IsAssignableTo(typeof(PowerModel)))
         {
-            return new((card)=>HoverTipFactory.FromPower(ModelDb.GetById<PowerModel>(ModelDb.GetId(t))));
+            return new((card)=>BetaMainCompatibility._HoverTipFactory.FromPower(ModelDb.GetById<PowerModel>(ModelDb.GetId(t))));
         }
         if (t.IsAssignableTo(typeof(CardModel)))
         {


### PR DESCRIPTION
- Rewrite AsyncMethodCall to fix some issues (closes #235)
- Add extension on ModelDb to get CardModifier instance (requires language level 14 to use, otherwise can call `CardModifier.Get`
- MoveBuilder helper for defining monster moves
- Bugfixes/additional model type support for temporary power model (closes #254)
- Add uid:// and user:// path support to some methods (closes #260)
- SeenByDefault property on custom pools
- Fix scene conversion registration for CustomMonsterModel