### PR TITLE
Add override for shared enum props

### DIFF
--- a/Config/ConfigAttributes.cs
+++ b/Config/ConfigAttributes.cs
@@ -297,3 +297,21 @@ public class ConfigColorPickerAttribute : Attribute
     /// </summary>
     public bool EditIntensity { get; set; } = false;
 }
+
+/// <summary>
+/// <para>Overrides the default localization key prefix used for enum values.</para>
+/// <para>By default, enum localization keys include the property name as part of the key. For example,
+/// a property named <c>CardOption1</c> with enum value <c>BladeOfInk</c> would use the localization key
+/// <c>{modName}-CARDOPTION1.BladeOfInk</c>.</para>
+/// <para>Apply this attribute to multiple enum properties that should share the same localization entries.
+/// When specified, the provided override value is used instead of the property name when generating
+/// localization keys.</para>
+/// <para>For example, if both <c>CardOption1</c> and <c>CardOption2</c> use an override value of
+/// <c>CARD_OPTIONS</c>, the enum value <c>BladeOfInk</c> will use the key
+/// <c>{modName}-CARD_OPTIONS.BladeOfInk</c> for both properties.</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class ConfigEnumLocalizationOverrideAttribute(string overridePropertyName) : Attribute
+{
+    public string OverridePropertyName { get; } = overridePropertyName;
+}

--- a/Config/UI/NConfigDropdown.cs
+++ b/Config/UI/NConfigDropdown.cs
@@ -46,9 +46,11 @@ public partial class NConfigDropdown : NSettingsDropdown
         var type = property.PropertyType;
         if (!type.IsEnum) throw new NotSupportedException("Dropdown only supports enum types currently");
 
+        var overrideProperty = property.GetCustomAttribute<ConfigEnumLocalizationOverrideAttribute>();
+        var propertyName = overrideProperty?.OverridePropertyName ?? StringHelper.Slugify(property.Name);
         foreach (var value in type.GetEnumValues())
         {
-            var loc = LocString.GetIfExists("settings_ui", $"{modPrefix}{StringHelper.Slugify(property.Name)}.{value}");
+            var loc = LocString.GetIfExists("settings_ui", $"{modPrefix}{propertyName}.{value}");
             var label = loc?.GetRawText() ?? value?.ToString() ?? "UNKNOWN";
 
             _items.Add(new NConfigDropdownItem.ItemData(label, value, () =>


### PR DESCRIPTION
Give option to overwrite the Prop substring of the localization strings so they can be shared between enum properties