### PR TITLE
Revert title change for label

### DIFF
--- a/Config/SimpleModConfig.cs
+++ b/Config/SimpleModConfig.cs
@@ -190,12 +190,7 @@ public class SimpleModConfig : ModConfig
     {
         var control = controlCreator.Invoke(property);
         
-        var locOverrideAttr = property.GetCustomAttribute<ConfigOverrideLocalizationAttribute>();
-
-        var text = locOverrideAttr != null ? 
-            GetLabelText(locOverrideAttr.OverridePropertyName, false) : 
-            GetLabelText(property.Name);
-        
+        var text = GetLabelText(property.Name);
         var label = CreateRawLabelControl(text, 28);
         var option = new NConfigOptionRow(ModPrefix, property.Name, label, control);
         control.ClearFocusNeighbors();


### PR DESCRIPTION
In reference to this comment:
https://github.com/Alchyr/BaseLib-StS2/pull/272/changes/58cd680449e68a0bba331758527f01cbaa8011f1#r3388204152

I feel like we should be able to share the values but not the label title.