### PR TITLE
Make CustomReward's FromSerializable Constructor not required to be static

### DIFF
--- a/Abstracts/CustomReward.cs
+++ b/Abstracts/CustomReward.cs
@@ -49,12 +49,11 @@ public abstract class CustomReward(Player player) : Reward(player)
 
     /// <summary>
     /// Delegate to create your reward type from the saved data.
-    /// The method reference must be of a <see langword="static"/> method
     /// </summary>
     /// <example>
     /// <code>
     /// // in MyCustomReward.cs
-    /// public static MyCustomReward CreateFromSerializable(SerializableReward save, Player player)
+    /// public MyCustomReward CreateFromSerializable(SerializableReward save, Player player)
     /// {
     ///     return new MyCustomReward(player) {
     ///         MyCustomNumber = save.GoldAmount
@@ -71,12 +70,8 @@ public abstract class CustomReward(Player player) : Reward(player)
     /// </summary>
     public virtual void Initialize()
     {
-        if (DeserializeMethod.Target != null)
-        {
-            throw new ArgumentException($"DeserializeMethod of {GetType()} is not static");
-        }
         BaseLibMain.Logger.Info($"Registering CustomReward deserializer for {GetType()}");
-        CustomRewardPatches.RegisterCustomReward(RewardType, DeserializeMethod);
+        CustomRewardPatches.RegisterCustomReward(RewardType, this, DeserializeMethod);
     }
 }
 

--- a/Abstracts/CustomReward.cs
+++ b/Abstracts/CustomReward.cs
@@ -66,7 +66,7 @@ public abstract class CustomReward(Player player) : Reward(player)
 
     /// <summary>
     /// Base method to handle registering your reward for serializing and deserializing in <see cref="RewardSynchronizer"/>
-    /// Override this if you wish to manually register your reward with <see cref="CustomRewardPatches.RegisterCustomReward(RewardType, CreateRewardFromSave&lt;CustomReward&gt;)"/>
+    /// Override this if you wish to manually register your reward with <see cref="CustomRewardPatches.RegisterCustomReward(RewardType, (this, CreateRewardFromSave&lt;CustomReward&gt;))"/>
     /// </summary>
     public virtual void Initialize()
     {

--- a/Patches/Content/CustomRewardPatches.cs
+++ b/Patches/Content/CustomRewardPatches.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using BaseLib;
 using BaseLib.Abstracts;
 using BaseLib.Patches.Content;
@@ -11,9 +12,9 @@ namespace Baselib.Patches.Content;
 [HarmonyPatch(typeof(Reward))]
 internal static class CustomRewardPatches
 {
-    internal static readonly Dictionary<RewardType, CreateRewardFromSave<CustomReward>> _RewardTypeDeserializers = [];
+    internal static readonly Dictionary<RewardType, (Type, CreateRewardFromSave<CustomReward>)> _RewardTypeDeserializers = [];
 
-    public static void RegisterCustomReward(RewardType type, CreateRewardFromSave<CustomReward> deserializer)
+    public static void RegisterCustomReward(RewardType type, CustomReward rewardClass, CreateRewardFromSave<CustomReward> deserializer)
     {
         if (_RewardTypeDeserializers.ContainsKey(type))
         {
@@ -21,7 +22,7 @@ internal static class CustomRewardPatches
         }
 
         BaseLibMain.Logger.Info($"Registering RewardType {CustomEnums.EnumName<RewardType>((int)type)}");
-        _RewardTypeDeserializers.Add(type, deserializer);
+        _RewardTypeDeserializers.Add(type, (rewardClass.GetType(), deserializer));
     }
 
     [HarmonyPatch(nameof(Reward.FromSerializable))]
@@ -33,11 +34,11 @@ internal static class CustomRewardPatches
             BaseLibMain.Logger.Info($"Found RewardType {CustomEnums.EnumName<RewardType>((int)save.RewardType)} in registry from mod {_RewardTypeDeserializers[save.RewardType].GetType().Assembly}");
 
             var method = _RewardTypeDeserializers[save.RewardType];
-            __result = method.Invoke(save, player);
+            __result = method.Item2.GetMethodInfo().Invoke(method.Item1.CreateInstance(), [save, player]) as Reward;
             return false;
         }
 
-        BaseLibMain.Logger.Warn($"No CustomReward found for RewardType {save.RewardType}, proceeding to basegame method");
+        BaseLibMain.Logger.Info($"No CustomReward found for RewardType {save.RewardType}, proceeding to basegame method");
         return true;
     }
 }

--- a/Patches/Content/RewardSynchronizerPatches.cs
+++ b/Patches/Content/RewardSynchronizerPatches.cs
@@ -27,30 +27,33 @@ public static class RewardSynchronizerExtensions
         public CustomTargetedMessageWrapper Message;
     }
 
-    // Not used in BaseLib as publicizer is enabled, but useful for mods without.
-    /// <summary>
-    /// Exposes the private INetGameService property.
-    /// </summary>
-    public static INetGameService? GameService(this RewardSynchronizer rewardSynchronizer) => rewardSynchronizer._gameService;
-    
+    extension(RewardSynchronizer rewardSynchronizer)
+    {
+        // Not used in BaseLib as publicizer is enabled, but useful for mods without.
+        /// <summary>
+        /// Exposes the private INetGameService property.
+        /// </summary>
+        public INetGameService GameService => rewardSynchronizer._gameService;
+
+        /// <summary>
+        /// Add a <see cref="CustomTargetedMessageWrapper"/> to the combat buffer
+        /// </summary>
+        public void BufferCustomRewardMessage(CustomTargetedMessageWrapper message, ulong senderId)
+        {
+            var bufferedMessage = new BufferedCustomRewardMessage
+            {
+                SenderId = senderId,
+                Message = message
+            };
+            BufferedCustomRewardMessages[rewardSynchronizer]?.Add(bufferedMessage);
+        }
+    }
+
     /// <summary>
     /// Reference list of buffered messages<br/>
     /// </summary>
     internal static readonly SpireField<RewardSynchronizer, List<BufferedCustomRewardMessage>>
         BufferedCustomRewardMessages = new(() => []);
-
-    /// <summary>
-    /// Add a <see cref="CustomRewardMessage"/> to the combat buffer
-    /// </summary>
-    public static void BufferCustomRewardMessage(this RewardSynchronizer rewardSynchronizer, CustomTargetedMessageWrapper message, ulong senderId)
-    {
-        var bufferedMessage = new BufferedCustomRewardMessage
-        {
-            SenderId = senderId,
-            Message = message
-        };
-        BufferedCustomRewardMessages[rewardSynchronizer]!.Add(bufferedMessage);
-    }
 
     [HarmonyPatch(nameof(RewardSynchronizer.OnCombatEnded))]
     [HarmonyPrefix]
@@ -58,8 +61,8 @@ public static class RewardSynchronizerExtensions
     {
         foreach (var bufferedMessage in BufferedCustomRewardMessages[__instance]!)
         {
-            __instance._messageBuffer?.CallHandlersOfType(bufferedMessage.Message.GetType(), bufferedMessage.Message, bufferedMessage.SenderId);
+            __instance._messageBuffer.CallHandlersOfType(bufferedMessage.Message.GetType(), bufferedMessage.Message, bufferedMessage.SenderId);
         }
-        BufferedCustomRewardMessages[__instance]!.Clear();
+        BufferedCustomRewardMessages[__instance]?.Clear();
     }
 }


### PR DESCRIPTION
doesn't have to be static anymore :) 
this is breaking for anyone who was overriding `Initialize`, but it just requires adding a class reference (typically `this` into the call to `RegisterCustomReward`

Potentially could make it not breaking by doing some reflection stuff with `GetCallingMethod`, but i think this it's a bit cleaner without that.