### PR TITLE
Mod config: make Restore Defaults method virtual

### DIFF
--- a/Config/ModConfig.cs
+++ b/Config/ModConfig.cs
@@ -160,7 +160,7 @@ public abstract partial class ModConfig
     /// [<see cref="ConfigIgnoreAttribute">ConfigIgnore</see>] or
     /// [<see cref="ConfigIgnoreRestoreDefaultsAttribute">ConfigIgnoreRestoreDefaults</see>].
     /// </summary>
-    protected void RestoreDefaultsNoConfirm()
+    protected virtual void RestoreDefaultsNoConfirm()
     {
         foreach (var property in ConfigProperties)
         {


### PR DESCRIPTION
I believe this is ABI safe; correct me if I'm wrong!

This adds flexibility for custom UIs for which restoring the saved properties might not be enough, or might not be want the mod author wants to do. (I found a case where this is probably best way to solve a custom UI, where Restore Defaults currently breaks it.)