### PR TITLE
Bound the log buffer and reduce off-thread Godot access in the logger

### DIFF
--- a/BaseLibScenes/NLogWindow.cs
+++ b/BaseLibScenes/NLogWindow.cs
@@ -15,10 +15,20 @@ public partial class NLogWindow : Window
     private static ImmutableList<NLogWindow> _listeners = ImmutableList<NLogWindow>.Empty;
     private static bool _openedOnErr = false;
 
-    private static List<string> _fullLog = [];
+    // Hard cap on retained log lines. Must comfortably exceed the max display size
+    // (the LimitedLogSize slider tops out at 2048) so RegenText always has enough history.
+    private const int MaxBufferedLines = 8192;
+    // Trim in chunks so the front-removal cost is amortized to ~O(1) per added line.
+    private const int TrimChunk = 1024;
+
+    private static readonly List<string> _fullLog = [];
+    // Logical index of _fullLog[0] (i.e. how many lines have been dropped off the front).
+    private static int _logBaseIndex = 0;
+    // Logical total line count ever seen = _logBaseIndex + _fullLog.Count. Monotonically increasing.
     private static int _fullLogCount = 0;
-    
+
     public int Limit { get; private set; } = BaseLibConfig.LimitedLogSize;
+    // Logical index of the next line this window needs to render.
     private int _writeIndex = 0;
 
     public static bool IsOpen => _listeners.Count > 0;
@@ -28,9 +38,17 @@ public partial class NLogWindow : Window
         lock (_logLock)
         {
             _fullLog.Add(msg);
-            _fullLogCount = _fullLog.Count;
+            if (_fullLog.Count > MaxBufferedLines + TrimChunk)
+            {
+                int remove = _fullLog.Count - MaxBufferedLines;
+                _fullLog.RemoveRange(0, remove);
+                _logBaseIndex += remove;
+            }
+            _fullLogCount = _logBaseIndex + _fullLog.Count;
         }
 
+        // SetDirty only sets a managed bool, so it is safe to call from the background
+        // threads the engine logs (and therefore this listener) can run on.
         foreach (var window in _listeners)
         {
             window.SetDirty();
@@ -222,18 +240,22 @@ public partial class NLogWindow : Window
     {
         _logLabel?.Clear();
         int validLineCount = 0;
-        
+
         lock (_logLock)
         {
-            for (_writeIndex = _fullLog.Count - 1; _writeIndex > 0; _writeIndex--)
+            // Default to rendering everything currently buffered. This also handles the
+            // empty-buffer case: _writeIndex == _fullLogCount, so UpdateText reads nothing.
+            _writeIndex = _logBaseIndex;
+
+            for (int i = _fullLog.Count - 1; i >= 0; i--)
             {
-                if (MatchesFilter(_fullLog[_writeIndex]))
+                if (!MatchesFilter(_fullLog[i])) continue;
+
+                ++validLineCount;
+                if (validLineCount >= BaseLibConfig.LimitedLogSize)
                 {
-                    ++validLineCount;
-                    if (validLineCount >= BaseLibConfig.LimitedLogSize)
-                    {
-                        break;
-                    }
+                    _writeIndex = _logBaseIndex + i; // logical index of this line
+                    break;
                 }
             }
         }
@@ -268,7 +290,14 @@ public partial class NLogWindow : Window
         while (_writeIndex < _fullLogCount)
         {
             string line;
-            lock (_logLock) line = _fullLog[_writeIndex];
+            lock (_logLock)
+            {
+                // If this window fell so far behind that its next line was already trimmed
+                // off the front, skip ahead to the oldest line still retained.
+                if (_writeIndex < _logBaseIndex) _writeIndex = _logBaseIndex;
+                if (_writeIndex >= _fullLogCount) break;
+                line = _fullLog[_writeIndex - _logBaseIndex];
+            }
             if (MatchesFilter(line))
             {
                 RenderLine(line, minLevel, _logLabel);

--- a/Patches/Utils/LogPatch.cs
+++ b/Patches/Utils/LogPatch.cs
@@ -47,7 +47,11 @@ public partial class LogListener : Godot.Logger
         var formatted = $"[{level}] {cleanMsg}";
         NLogWindow.AddLog(formatted);
 
-        if (level == "ERROR") Callable.From(NLogWindow.OpenOnErr).CallDeferred();
+        // This runs on whatever (possibly background) thread emitted the log. Only marshal
+        // to the main thread when the auto-open feature is actually enabled, so the common
+        // case never allocates a Callable or touches Godot off-thread on every error line.
+        if (level == "ERROR" && BaseLibConfig.OpenLogWindowOnError)
+            Callable.From(NLogWindow.OpenOnErr).CallDeferred();
     }
 
     public override void _LogError(string function, string file, int line, string code, string rationale, bool editorNotify, int errorType,
@@ -55,15 +59,25 @@ public partial class LogListener : Godot.Logger
     {
         var errorName = ((ErrorType)errorType).ToString();
         StringBuilder msg = new StringBuilder().Append($"[ERROR] Error occurred [{errorName}]: {rationale}\n{code}\n{file}:{line} @ {function}()\n");
-        foreach (var backtrace in scriptBacktraces)
+        // Defensive: this callback can fire on any thread; never let a hiccup formatting the
+        // backtrace throw out of the logger (which would itself be logged as another error).
+        try
         {
-            if (backtrace.IsEmpty()) continue;
-            msg.Append($"{backtrace.Format()}");
+            foreach (var backtrace in scriptBacktraces)
+            {
+                if (backtrace.IsEmpty()) continue;
+                msg.Append($"{backtrace.Format()}");
+            }
+        }
+        catch
+        {
+            // ignored
         }
 
         NLogWindow.AddLog(msg.ToString());
-        
-        Callable.From(NLogWindow.OpenOnErr).CallDeferred();
+
+        if (BaseLibConfig.OpenLogWindowOnError)
+            Callable.From(NLogWindow.OpenOnErr).CallDeferred();
     }
 }
 


### PR DESCRIPTION
Fixes #297. Likely fixes #296 (crash with no error/warning log, only with BaseLib, appeared in 3.3.0). Complements the in-progress log work for #295.

### What this fixes
`LogListener` (registered via `OS.AddLogger` in `BaseLibMain.Initialize`) receives **every** Godot log line — STS2 routes all logging through `GD.Print`/`GD.PrintErr` — and feeds them into a static `_fullLog` that is never trimmed. It grows for the whole session from the moment BaseLib loads, so under a heavy stream (e.g. the thousands of save-parse warnings at startup) it can exhaust memory and crash natively **with no managed log**. The listener also marshalled to the main thread (`Callable.From` + `CallDeferred`) on every error line, from whatever background thread the engine logged on, even when auto-open was disabled.

Confirmed via a Sentry native minidump from a live `v0.107.1` / Godot `4.5.1` session: `0xC0000005`, null `this` read at `+0x58`, main thread, native engine code, during startup/asset-load.

### Changes
**`NLogWindow`**
- Re-bound `_fullLog` (`MaxBufferedLines` + chunked front-trim), tracking a `_logBaseIndex` logical offset so each window's `_writeIndex` stays valid across trims.
- `RegenText`/`UpdateText` clamp to the retained range; this also fixes the empty-buffer path that indexed `_fullLog[-1]`.

**`LogListener` (`Patches/Utils/LogPatch.cs`)**
- Only defer `OpenOnErr` when `OpenLogWindowOnError` is enabled, so the common case never allocates a `Callable` / touches Godot off the main thread per error line.
- Guard `_LogError` backtrace formatting with try/catch so the logger can't throw back into the engine's log call.

### Relationship to `develop` (no overlap)
Branched off `develop`. The three defects above are all still present there, and this PR is additive:
- `_fullLog` is still unbounded on `develop` → this PR bounds it (the root cause of the no-log native crash).
- `Patches/Utils/LogPatch.cs` is unchanged on `develop` → off-thread work fixed here.
- `d9757b7`'s `safety = 64` paragraph-trim cap is **kept intact** — it bounds removals per call, while this PR bounds the backing buffer itself.
- (FYI) `_Process` on `develop` still has a leftover `BaseLibMain.Logger.Info("AAAAA")` that self-floods the log every frame — not touched here, but worth removing.
