### PR TITLE
Resolve the custom-message patch target across game versions

### DIFF
--- a/Patches/Networking/CustomMessagePatches.cs
+++ b/Patches/Networking/CustomMessagePatches.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using BaseLib.Abstracts;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Multiplayer.Serialization;
@@ -25,9 +26,30 @@ internal static class RunManagerPatches
     }
 }
 
-[HarmonyPatch(typeof(MessageTypes), nameof(MessageTypes.Initialize))]
+[HarmonyPatch]
 static class AdjustCustomMessageKeys
 {
+    // v0.107.1+ (re)builds the network message-type cache in MessageTypes.Initialize().
+    // Older builds did it in the type's static constructor instead. Resolve whichever this
+    // game version actually has so the wrapper-id fixup still runs after the cache is built;
+    // if neither exists, skip the patch cleanly instead of throwing "Undefined target method".
+    private static MethodBase? _target;
+
+    static bool Prepare()
+    {
+        _target ??= AccessTools.DeclaredMethod(typeof(MessageTypes), nameof(MessageTypes.Initialize))
+                    ?? (MethodBase?)typeof(MessageTypes).TypeInitializer;
+
+        if (_target is null)
+            BaseLibMain.Logger.Warn(
+                "MessageTypes.Initialize (and its static constructor) could not be found; custom " +
+                "network message wrappers will not be registered for this game version.");
+
+        return _target is not null;
+    }
+
+    static MethodBase TargetMethod() => _target!;
+
     [HarmonyPostfix]
     static void Fuckery()
     {


### PR DESCRIPTION
Fixes [discord message](https://discord.com/channels/309399445785673728/1478917653551906947/1518058482484641804)

### Problem
On startup the logger reports:

```
[ERROR] [BaseLib] HarmonyLib.HarmonyException: Patching exception in method null
 ---> System.ArgumentException: Undefined target method for patch method
      static System.Void BaseLib.Patches.Networking.AdjustCustomMessageKeys::Fuckery()
```

`AdjustCustomMessageKeys` hard-targets `MessageTypes.Initialize` via `[HarmonyPatch(typeof(MessageTypes), nameof(MessageTypes.Initialize))]`. `MessageTypes` was refactored across the v0.107.0 → v0.107.1 boundary:

- **v0.107.0 and earlier:** the message-type cache was built in the **static constructor** (`static MessageTypes()`) — there was no `Initialize` method.
- **v0.107.1:** the static ctor was removed and a `public static void Initialize()` added.

So on any build where `Initialize` is absent (e.g. a slightly older game than the BaseLib build was compiled against), Harmony can't resolve the target and throws. `TryPatchAll` catches it, but the patch never applies — so custom network message wrappers don't get their IDs assigned (multiplayer custom messages break), and the log shows a scary exception.

### Fix
Resolve the target dynamically in `Prepare()`:
- prefer `MessageTypes.Initialize()`,
- fall back to the type's static constructor (`Type.TypeInitializer`) — `NetTypeCache`'s internals are byte-for-byte identical across these versions (only doc comments differ), so the existing postfix body works either way,
- if neither exists, log a clear warning and skip the patch (return `false`) instead of throwing `HarmonyException`.

This keeps the patch working on the current game (v0.107.1, uses `Initialize`), restores it on older builds (static ctor), and degrades gracefully on any future version where the target moves again.
