### PR TITLE
Ensure cloned card modifiers have independent dynamic vars

### DIFF
--- a/Abstracts/CardModifier.cs
+++ b/Abstracts/CardModifier.cs
@@ -388,6 +388,19 @@ public abstract class CardModifier : AbstractModel, IComparable<CardModifier>
     {
         return Priority.CompareTo(other?.Priority ?? 0);
     }
+    
+    /// <summary>
+    /// Gives the clone its own <see cref="DynamicVars"/> instead of sharing the original's set.
+    /// </summary>
+    /// <remarks>
+    /// Must run after <see cref="Owner"/> is set to the clone, not in DeepCloneFields, where Card Owner
+    /// is still the original card.
+    /// </remarks>
+    internal void CloneDynamicVarsForClone()
+    {
+        if (_dynamicVars != null && Owner != null)
+            _dynamicVars = _dynamicVars.Clone(Owner);
+    }
 }
 
 [HarmonyPatch(typeof(AbstractModel), nameof(AbstractModel.MutableClone))]
@@ -401,6 +414,7 @@ static class CloneModifiers {
             {
                 var cloneModifier = (CardModifier) modifier.MutableClone();
                 resultCard.AddModifier(cloneModifier);
+                cloneModifier.CloneDynamicVarsForClone();
                 cloneModifier.AfterClonedOnCard(resultCard);
             }
         }


### PR DESCRIPTION
MutableClone only shallow-copies, so a cloned modifier shared the
original's DynamicVarSet; upgrades and previews leaked between them.


i.e a simple example where the CardModifier has OnUpgrade with +5 for a power var:

https://github.com/user-attachments/assets/bee1373a-a407-4f0d-8065-63125ca5fe64

This was an issue, for example, when NGridCardHolder.UpdateCardModel
clones the card and upgrades the clone, which modified the unupgraded original.