### PR TITLE
change Purge description's "deck" to (gold) "Deck"

### DIFF
--- a/BaseLib/localization/eng/card_keywords.json
+++ b/BaseLib/localization/eng/card_keywords.json
@@ -1,4 +1,4 @@
 {
   "BASELIB-PURGE.title": "Purge",
-  "BASELIB-PURGE.description": "Removed from combat and your deck permanently."
+  "BASELIB-PURGE.description": "Removed from combat and your [gold]Deck[/gold] permanently."
 }


### PR DESCRIPTION
change "deck" to "[gold]Deck[/gold]" to stay consistent with the basegame's usage of the term