### PR TITLE
add LoadFolders patch to dynamically load mod directories based on platform branch

### DIFF
--- a/Patches/Features/LoadFoldersPatch.cs
+++ b/Patches/Features/LoadFoldersPatch.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Modding;
+using MegaCrit.Sts2.Core.Platform;
+
+namespace BaseLib.Patches.Features;
+
+[HarmonyPatch(typeof(ModManager), "TryLoadMod")]
+public static class LoadFoldersPatch
+{
+    [HarmonyPrefix]
+    private static void Prefix(Mod mod)
+    {
+        var loadFoldersPath = Path.Combine(mod.path, "loadFolders");
+        if (!File.Exists(loadFoldersPath))
+            return;
+
+        try
+        {
+            var json = File.ReadAllText(loadFoldersPath);
+            var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+
+            if (map == null)
+            {
+                BaseLibMain.Logger.Warn($"[LoadFolders] {mod.manifest?.id}: loadFolders deserialized to null");
+                return;
+            }
+
+            var branch = PlatformUtil.GetPlatformBranch();
+            var branchName = branch.ToName();
+
+            if (!map.TryGetValue(branchName, out var subdir))
+            {
+                BaseLibMain.Logger
+                    .Info($"[LoadFolders] {mod.manifest?.id}: no entry for branch '{branchName}', loading from root");
+                return;
+            }
+
+            subdir = subdir.TrimStart('/', '\\');
+            var resolvedPath = Path.Combine(mod.path, subdir);
+
+            BaseLibMain.Logger
+                .Info($"[LoadFolders] {mod.manifest?.id}: loading folder '{resolvedPath}' for branch '{branchName}'");
+
+            mod.path = resolvedPath;
+        }
+        catch (Exception e)
+        {
+            BaseLibMain.Logger.Warn($"[LoadFolders] {mod.manifest?.id}: failed to process loadFolders: {e}");
+        }
+    }
+}


### PR DESCRIPTION
Adds support for 'loadFolders' files, a new optional file mods can place in their root directory to load different DLL/PCK builds depending on the active Steam branch. This is to allow mod developers to upload different versions of the mod within the same workshop item and have Baselib load the correct version based off of the version loaded.
pck file included in both due to godot uuid goodness.

Tested on both v108 public-beta and on v107.1 main.

LoadFolders is a json but not declared as one, because v107 tries to load it as a mod mainfest.

loadFolders format:
```
{
  "public": "stable",
  "public-beta": "beta"
}
```

mod folder structure example with using loadFolders:
<img width="187" height="216" alt="image" src="https://github.com/user-attachments/assets/44495c84-d24b-4daa-b243-bfdd760340c9" />
