### PR TITLE
Add NativeFileDialogChrome for improved file dialog handling

### DIFF
--- a/Config/BaseLibConfig.cs
+++ b/Config/BaseLibConfig.cs
@@ -46,6 +46,9 @@ internal class BaseLibConfig : SimpleModConfig
             Access = FileDialog.AccessEnum.Filesystem,
             CurrentFile = "baselib_harmony_patch_dump.log",
         };
+        if (!string.IsNullOrWhiteSpace(HarmonyPatchDumpOutputPath))
+            dialog.CurrentPath = HarmonyPatchDumpOutputPath;
+
         dialog.AddFilter("*.log", "Log");
         dialog.AddFilter("*.txt", "Text");
 
@@ -56,10 +59,8 @@ internal class BaseLibConfig : SimpleModConfig
             config.ConfigReloaded();
             dialog.QueueFree();
         };
-        dialog.Canceled += dialog.QueueFree;
 
-        tree.Root.AddChild(dialog);
-        dialog.PopupCenteredRatio(0.55f);
+        NativeFileDialogChrome.Popup(dialog);
     }
 
     [ConfigButton("HarmonyDumpNow")]

--- a/Config/NativeFileDialogChrome.cs
+++ b/Config/NativeFileDialogChrome.cs
@@ -1,0 +1,106 @@
+using Godot;
+
+namespace BaseLib.Config;
+
+internal static class NativeFileDialogChrome
+{
+    private const int FileDialogLayer = 132;
+
+    public static void Popup(FileDialog dialog, float centeredRatio = 0.55f)
+    {
+        var tree = Engine.GetMainLoop() as SceneTree;
+        if (tree?.Root == null)
+        {
+            dialog.QueueFree();
+            return;
+        }
+
+        var viewport = tree.Root.GetViewport();
+        var previousFocus = viewport?.GuiGetFocusOwner();
+        var previousMouseMode = Input.MouseMode;
+
+        var layer = new CanvasLayer
+        {
+            Name = "BaseLibNativeFileDialogModal",
+            Layer = FileDialogLayer,
+        };
+        tree.Root.AddChild(layer);
+
+        var shield = new Control
+        {
+            Name = "FileDialogShieldRoot",
+            MouseFilter = Control.MouseFilterEnum.Stop,
+        };
+        layer.AddChild(shield);
+
+        var dim = new ColorRect
+        {
+            Name = "FileDialogDim",
+            Color = new Color(0f, 0f, 0f, 0.55f),
+            MouseFilter = Control.MouseFilterEnum.Stop,
+        };
+        dim.SetAnchorsAndOffsetsPreset(Control.LayoutPreset.FullRect);
+        shield.AddChild(dim);
+
+        layer.AddChild(dialog);
+        ConfigureDialog(dialog);
+        Callable.From(FitShieldToViewport).CallDeferred();
+        if (viewport != null)
+            viewport.SizeChanged += FitShieldToViewport;
+
+        dialog.Canceled += CloseDialog;
+        dialog.CloseRequested += CloseDialog;
+        dialog.TreeExiting += RestoreMouseAndFocus;
+
+        Input.MouseMode = Input.MouseModeEnum.Visible;
+        dialog.PopupCenteredRatio(centeredRatio);
+        return;
+
+        void FitShieldToViewport()
+        {
+            if (!GodotObject.IsInstanceValid(shield) || viewport == null)
+                return;
+
+            var rect = viewport.GetVisibleRect();
+            shield.Position = rect.Position;
+            shield.Size = rect.Size;
+        }
+
+        void CloseDialog()
+        {
+            if (GodotObject.IsInstanceValid(dialog))
+                dialog.QueueFree();
+        }
+
+        void RestoreMouseAndFocus()
+        {
+            if (GodotObject.IsInstanceValid(viewport))
+                viewport.SizeChanged -= FitShieldToViewport;
+
+            Input.MouseMode = previousMouseMode;
+
+            if (GodotObject.IsInstanceValid(layer))
+                layer.QueueFree();
+
+            var target = previousFocus;
+            if (target == null || !GodotObject.IsInstanceValid(target) || !target.IsVisibleInTree())
+                return;
+
+            Callable.From(() =>
+            {
+                if (GodotObject.IsInstanceValid(target) && target.IsVisibleInTree())
+                    target.GrabFocus();
+            }).CallDeferred();
+        }
+    }
+
+    private static void ConfigureDialog(FileDialog dialog)
+    {
+        dialog.Name = "BaseLibNativeFileDialog";
+        dialog.Exclusive = true;
+        dialog.Unresizable = false;
+        dialog.Transparent = false;
+        dialog.MinSize = new Vector2I(760, 520);
+        dialog.Size = dialog.MinSize;
+    }
+}


### PR DESCRIPTION
The previous implementation did not handle cursor display correctly (resulting in the mouse position being invisible after opening the interface), and it did not restore focus when closed, so this fix is submitted to optimize the behavior.
For better support, such as full gamepad operation, a complete implementation of the file selector might be needed, but since this is generally used for development troubleshooting, it feels that reasonable mouse support is sufficient for now.