### PR TITLE
Feature: Card type text modifiers

### DIFF
--- a/Abstracts/ICustomTypeTextCard.cs
+++ b/Abstracts/ICustomTypeTextCard.cs
@@ -1,0 +1,18 @@
+using BaseLib.Hooks;
+using MegaCrit.Sts2.Core.Localization;
+
+namespace BaseLib.Abstracts;
+
+/// <summary>
+/// Interface that can be implemented on a card class to have that card visually modify its own type text.
+/// To make models other than cards modify card type text, see <see cref="ICardTypeTextModifier"/>.
+/// </summary>
+public interface ICustomTypeTextCard
+{
+    /// <summary>
+    /// Return a list of <c>LocString</c>s.
+    /// Each of these strings has access to the formatting argument <c>{Type}</c>, which will be replaced by the original type text.
+    /// </summary>
+    /// <returns>A list of <c>LocString</c>s, each of which should point to a string for a card type text modification.</returns>
+    public IEnumerable<LocString> GetTypeModifiers();
+}

--- a/Hooks/ICardTypeTextModifier.cs
+++ b/Hooks/ICardTypeTextModifier.cs
@@ -1,0 +1,21 @@
+using BaseLib.Abstracts;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Models;
+
+namespace BaseLib.Hooks;
+
+/// <summary>
+/// Interface for visually modifying cards' type text.
+/// Intended for use on models other than cards. To have a card modify its own type text, see
+/// <see cref="ICustomTypeTextCard" />.
+/// </summary>
+public interface ICardTypeTextModifier
+{
+    /// <summary>
+    /// Return a list of <c>LocString</c>s.
+    /// Each of these strings has access to the formatting argument <c>{Type}</c>, which will be replaced by the original type text.
+    /// </summary>
+    /// <param name="card">The card to get the type text modifiers for.</param>
+    /// <returns>A list of <c>LocString</c>s, each of which should point to a string for a card type text modification.</returns>
+    public IEnumerable<LocString> GetTypeModifiers(CardModel card);
+}

--- a/Patches/UI/AddSubtypesToTypePlaquePatch.cs
+++ b/Patches/UI/AddSubtypesToTypePlaquePatch.cs
@@ -57,20 +57,22 @@ class AddSubtypesToTypePlaquePatch
             locStringList = locStringList.Concat(visualCardSubtypeSource.GetTypeModifiers(card));
         }
 
-        // Finally apply all gathered modifiers to the original plaque text
+        // Split modifiers by whether they reference the original type
+        var lookup = locStringList.ToLookup(locString => locString.GetRawText().Contains("{" + ArgName + "}"));
+
+        foreach (var locString in lookup[false])
+        {
+            // Modifiers that do NOT reference the original text should just replace it (race conditions be damned)
+            originalPlaqueText = locString;
+        }
+
+        // Finally, process modifiers that DO reference the original type
         var previousTypeText = originalPlaqueText;
 
-        foreach (var locString in locStringList)
+        foreach (var locString in lookup[true])
         {
-            if (locString.GetRawText().Contains("{"+ArgName+"}"))
-            {
-                locString.Add(ArgName, previousTypeText);
-                previousTypeText = locString;
-            }
-            else
-            {
-                previousTypeText.Add(ArgName, locString);
-            }
+            locString.Add(ArgName, previousTypeText);
+            previousTypeText = locString;
         }
 
         // And return

--- a/Patches/UI/AddSubtypesToTypePlaquePatch.cs
+++ b/Patches/UI/AddSubtypesToTypePlaquePatch.cs
@@ -1,0 +1,79 @@
+using System.Reflection.Emit;
+using BaseLib.Abstracts;
+using BaseLib.Hooks;
+using HarmonyLib;
+using MegaCrit.Sts2.addons.mega_text;
+using MegaCrit.Sts2.Core.Combat;
+using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Models;
+using MegaCrit.Sts2.Core.Nodes.Cards;
+using MegaCrit.Sts2.Core.Runs;
+
+namespace BaseLib.Patches.UI;
+
+[HarmonyPatch(typeof(NCard), nameof(NCard.UpdateTypePlaque))]
+class AddSubtypesToTypePlaquePatch
+{
+    [HarmonyTranspiler]
+    static List<CodeInstruction> AddVisualSubtypes(IEnumerable<CodeInstruction> instructions)
+    {
+        var codeMatcher = new CodeMatcher(instructions);
+
+        codeMatcher
+            .MatchStartForward(
+                CodeMatch.Calls(typeof(CardTypeExtensions).Method(nameof(CardTypeExtensions.ToLocString))),
+                CodeMatch.Calls(typeof(LocString).Method(nameof(LocString.GetFormattedText))),
+                CodeMatch.Calls(typeof(MegaLabel).Method(nameof(MegaLabel.SetTextAutoSize)))
+            )
+            .InsertAfterAndAdvance(
+                CodeInstruction.LoadArgument(0),
+                new CodeInstruction(OpCodes.Call, typeof(NCard).PropertyGetter(nameof(NCard.Model))),
+                CodeInstruction.Call(typeof(AddSubtypesToTypePlaquePatch), nameof(TryModifyPlaqueText))
+            );
+
+        return codeMatcher.Instructions();
+    }
+
+    private const string ArgName = "Type";
+
+    private static LocString TryModifyPlaqueText(LocString originalPlaqueText, CardModel card)
+    {
+        var runState = card.RunState ?? NullRunState.Instance;
+        var combatState = card.CombatState ?? NullCombatState.Instance;
+
+        IEnumerable<LocString> locStringList = [];
+
+        // First check if the card modifies its own type text
+        if (card is ICustomTypeTextCard customTypeTextCard)
+        {
+            locStringList = locStringList.Concat(customTypeTextCard.GetTypeModifiers());
+        }
+
+        // Then iterate over all hook listeners and get their type modifiers
+        foreach (var source in runState.IterateHookListeners(combatState))
+        {
+            if (source is not ICardTypeTextModifier visualCardSubtypeSource) continue;
+            locStringList = locStringList.Concat(visualCardSubtypeSource.GetTypeModifiers(card));
+        }
+
+        // Finally apply all gathered modifiers to the original plaque text
+        var previousTypeText = originalPlaqueText;
+
+        foreach (var locString in locStringList)
+        {
+            if (locString.GetRawText().Contains("{"+ArgName+"}"))
+            {
+                locString.Add(ArgName, previousTypeText);
+                previousTypeText = locString;
+            }
+            else
+            {
+                previousTypeText.Add(ArgName, locString);
+            }
+        }
+
+        // And return
+        return previousTypeText;
+    }
+}


### PR DESCRIPTION
Adds two new interfaces to allow for the text displayed on cards' typelines to be modified.
- `ICustomTypeTextCard` - Used on a card itself to innately add modifiers
- `ICardTypeTextModifier` - Used on other types of models to add modifiers to cards dynamically

Modifiers can be any LocString, but most will want to make use of the `{Type}` formatting argument given to them in the associated patch method, e.g.
```json
{
    "MYMOD-EPIC": "{Type} | Epic"
}
```
would produce `Attack | Epic` if applied to an Attack card with no other modifiers present.