### PR TITLE
Fix: energy icons in custom keyword tooltips outside of a run

### DIFF
--- a/Patches/Content/CustomEnums.cs
+++ b/Patches/Content/CustomEnums.cs
@@ -53,6 +53,14 @@ public sealed class KeywordPropertiesAttribute : Attribute
 
     public AutoKeywordPosition Position { get; }
     public bool RichKeyword { get; }
+
+    /// <summary>
+    /// The pool whose energy icon the keyword's tooltip should use, e.g. typeof(MyCardPool).
+    /// Only relevant for rich keywords whose description contains energy icons.
+    /// If not supplied, the icon is resolved from the character being played, which fails outside of a run
+    /// (in the card library the tooltip falls back to the colorless icon).
+    /// </summary>
+    public Type? Pool { get; set; }
 }
 
 public enum AutoKeywordPosition
@@ -71,7 +79,12 @@ public static class CustomKeywords
         public readonly string Key = key;
         public required AutoKeywordPosition AutoPosition { get; init; }
         public required bool RichKeyword { get; init; }
-        
+
+        /// <summary>
+        /// Pool supplying the energy icon for this keyword's tooltip. Null if the keyword did not declare one.
+        /// </summary>
+        public Type? PoolType { get; init; }
+
         public static implicit operator string(KeywordInfo info) => info.Key;
     }
 
@@ -315,7 +328,8 @@ class GenEnumValues
                 CustomKeywords.KeywordIDs.Add((int) key, new(keywordId)
                 {
                     AutoPosition = autoPosition,
-                    RichKeyword = poolAttribute?.RichKeyword ?? true
+                    RichKeyword = poolAttribute?.RichKeyword ?? true,
+                    PoolType = poolAttribute?.Pool
                 });
                 continue;
             }

--- a/Patches/Localization/CustomTooltips.cs
+++ b/Patches/Localization/CustomTooltips.cs
@@ -1,8 +1,10 @@
 ﻿using BaseLib.Patches.Content;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Entities.Cards;
+using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.HoverTips;
 using MegaCrit.Sts2.Core.Localization;
+using MegaCrit.Sts2.Core.Models;
 
 namespace BaseLib.Patches.Localization;
 
@@ -23,13 +25,26 @@ class CustomTooltips
                 if (info.RichKeyword)
                 {
                     LocString description = keyword.GetDescription();
-                    description.Add("energyPrefix", "");
+                    description.Add("energyPrefix", GetEnergyPrefix(info));
                     __result = new HoverTip(keyword.GetTitle(), description);
                     return false;
                 }
             }
-            
+
             return true;
+        }
+
+        /// <summary>
+        /// Resolve the keyword's energy icon from the pool it declared, the way the game resolves it for cards and
+        /// powers. An empty prefix makes EnergyIconsFormatter fall back to the character being played, which does not
+        /// exist outside of a run, so the tooltip would show the colorless icon in the card library.
+        /// </summary>
+        private static string GetEnergyPrefix(CustomKeywords.KeywordInfo info)
+        {
+            if (info.PoolType == null) return "";
+
+            AbstractModel? pool = ModelDb.GetByIdOrNull<AbstractModel>(ModelDb.GetId(info.PoolType));
+            return pool is IPoolModel ? EnergyIconHelper.GetPrefix(pool) : "";
         }
     }
 }


### PR DESCRIPTION
Fixes #337.

## Problem

Custom keyword tooltips containing energy icons render the correct icon during a run, but fall back to the colorless icon in the card library opened from the main menu, logging:

```
[WARN] No energy prefix found for EnergyIconsFormatter! Using colorless as a fallback.
```

## Cause

`CustomTooltips.DynamicKeywordTips` passes an empty prefix:

```csharp
description.Add("energyPrefix", "");
```

An empty value makes the game's `EnergyIconsFormatter` fall back to the character being played:

```csharp
if (string.IsNullOrEmpty(text) || text == "colorless")
    text = RunManager.Instance.GetLocalCharacterEnergyIconPrefix();
```

`GetLocalCharacterEnergyIconPrefix()` reads `LocalContext.GetMe(State)?.Character.CardPool` and returns null when there is no `RunState` — which is the case in the card library.

The game itself never relies on that fallback: `CardModel`, `PowerModel`, `PotionModel`, `RelicModel` and `EnchantmentModel` all populate the variable with `EnergyIconHelper.GetPrefix(this)`, which resolves from the model's own pool and therefore works outside a run. `HoverTipFactory.FromKeyword` only receives the keyword, and `KeywordInfo` carried no pool, so BaseLib had nothing to resolve from.

## Change

Let a keyword declare the pool its energy icon comes from:

```csharp
[CustomEnum]
[KeywordProperties(AutoKeywordPosition.None, Pool = typeof(MyCardPool))]
public static CardKeyword MyKeyword;
```

`KeywordPropertiesAttribute.Pool` is stored on `KeywordInfo.PoolType` at registration and used to resolve the prefix via `EnergyIconHelper.GetPrefix`, matching how the game does it for cards and powers.

Opt-in and backwards compatible: keywords that don't declare a pool still pass `""` and behave exactly as before.

## Testing

Tested with a custom character mod (custom `CustomCardPoolModel` with `TextEnergyIconPath`), hovering keyword tooltips in the card library from the main menu with no run active. Resolved tooltip text:

| Keyword | Before | After |
|---|---|---|
| No `Pool` declared | `colorless_energy_icon.png` | `colorless_energy_icon.png` (unchanged) |
| `Pool = typeof(AlchemistCardPool)` | `colorless_energy_icon.png` | `res://Alchemist/images/charui/text_energy.png` |

<img width="161" height="111" alt="Screenshot 2026-07-16 at 12 28 33 PM" src="https://github.com/user-attachments/assets/196ec069-df22-487b-adce-172ecd202d3b" />

The `No energy prefix found` warning no longer fires for keywords that declare a pool. Icons in-run are unaffected.

## Alternative considered: inferring the pool

This PR asks each keyword to name its pool. The alternative is to infer it: BaseLib already knows the keyword's declaring type and its mod prefix (`t.GetPrefix()`, used to build the keyword ID), so it could look for a custom card pool registered under that same prefix and use it when exactly one exists, falling back to `""` otherwise.

The upside is real — most character mods have exactly one card pool, so existing mods (including the one in #337) would be fixed with no code change at all.

The trade-offs:

- It picks a pool the author never named, which is wrong for a keyword that belongs to a colorless or shared pool.
- It's ambiguous for mods with more than one pool, so an explicit `Pool` would still be needed as an override.
- That makes inference strictly additive to this PR rather than an alternative to it.

I went with the explicit version because it's predictable and easy to build on, but I'm happy to add inference on top if you'd rather existing mods heal without changes — `Pool` would stay as the override.
