### PR TITLE
Add Scry hover tips support

### DIFF
--- a/BaseLib/localization/deu/static_hover_tips.json
+++ b/BaseLib/localization/deu/static_hover_tips.json
@@ -1,8 +1,14 @@
 {
   "BASELIB-PERSIST.title": "Beständig",
-  "BASELIB-PERSIST.description": "Diese Karte kehrt {Persist:cond:>1?[blue]{Persist}[/blue]-mal|einmal} pro Zug nach dem Ausspielen auf deine Hand zurück.",
+  "BASELIB-PERSIST.description": "Diese Karte kehrt [blue]X[/blue]-mal pro Zug nach dem Ausspielen auf deine Hand zurück.",
+  "BASELIB-PERSIST.smartDescription": "Diese Karte kehrt {Persist:cond:>1?[blue]{Persist}[/blue]-mal|einmal} pro Zug nach dem Ausspielen auf deine Hand zurück.",
   "BASELIB-EXHAUSTIVE.title": "Erschöpfend",
-  "BASELIB-EXHAUSTIVE.description": "Diese Karte wird nach {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |einer }{Exhaustive:plural:Verwendung|Verwendungen} [gold]Erschöpft[/gold].",
+  "BASELIB-EXHAUSTIVE.description": "Diese Karte wird nach [blue]X[/blue] Verwendungen [gold]Erschöpft[/gold].",
+  "BASELIB-EXHAUSTIVE.smartDescription": "Diese Karte wird nach {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |einer }{Exhaustive:plural:Verwendung|Verwendungen} [gold]Erschöpft[/gold].",
   "BASELIB-REFUND.title": "Erstattung",
-  "BASELIB-REFUND.description": "Wird Energie für diese Karte ausgegeben, werden bis zu [blue]{Refund}[/blue] dieser Energie zurückerstattet."
+  "BASELIB-REFUND.description": "Wird Energie für diese Karte ausgegeben, werden bis zu [blue]X[/blue] dieser Energie zurückerstattet.",
+  "BASELIB-REFUND.smartDescription": "Wird Energie für diese Karte ausgegeben, werden bis zu [blue]{Refund}[/blue] dieser Energie zurückerstattet.",
+  "BASELIB-SCRY.title": "Spähen",
+  "BASELIB-SCRY.description": "Sieh dir die obersten [blue]X[/blue] Karten deines [gold]Nachziehstapels[/gold] an. Du kannst beliebig viele davon abwerfen.",
+  "BASELIB-SCRY.smartDescription": "Sieh dir die {Scry:plural:oberste Karte|obersten [blue]{Scry:diff()}[/blue] Karten} deines [gold]Nachziehstapels[/gold] an. Du kannst {Scry:plural:sie|beliebig viele davon} abwerfen."
 }

--- a/BaseLib/localization/eng/static_hover_tips.json
+++ b/BaseLib/localization/eng/static_hover_tips.json
@@ -1,8 +1,14 @@
 {
   "BASELIB-PERSIST.title": "Persist",
-  "BASELIB-PERSIST.description": "This card returns to your hand the first {Persist:cond:>1?[blue]{Persist}[/blue] |}{Persist:plural:time|times} it is played each turn.",
+  "BASELIB-PERSIST.description": "This card returns to your hand the first [blue]X[/blue] times it is played each turn.",
+  "BASELIB-PERSIST.smartDescription": "This card returns to your hand the first {Persist:cond:>1?[blue]{Persist}[/blue] |}{Persist:plural:time|times} it is played each turn.",
   "BASELIB-EXHAUSTIVE.title": "Exhaustive",
-  "BASELIB-EXHAUSTIVE.description": "This card [gold]Exhausts[/gold] after {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}{Exhaustive:plural:use|uses}.",
+  "BASELIB-EXHAUSTIVE.description": "This card [gold]Exhausts[/gold] after [blue]X[/blue] uses.",
+  "BASELIB-EXHAUSTIVE.smartDescription": "This card [gold]Exhausts[/gold] after {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}{Exhaustive:plural:use|uses}.",
   "BASELIB-REFUND.title": "Refund",
-  "BASELIB-REFUND.description": "When energy is spent on this card, up to [blue]{Refund}[/blue] of that energy is refunded."
+  "BASELIB-REFUND.description": "When energy is spent on this card, up to [blue]X[/blue] of that energy is refunded.",
+  "BASELIB-REFUND.smartDescription": "When energy is spent on this card, up to [blue]{Refund}[/blue] of that energy is refunded.",
+  "BASELIB-SCRY.title": "Scry",
+  "BASELIB-SCRY.description": "Look at the top [blue]X[/blue] cards of your [gold]Draw Pile[/gold]. You may discard any of them.",
+  "BASELIB-SCRY.smartDescription": "Look at the top {Scry:plural:card|[blue]{Scry:diff()}[/blue] cards} of your [gold]Draw Pile[/gold]. You may discard {Scry:plural:it|any of them}."
 }

--- a/BaseLib/localization/ita/static_hover_tips.json
+++ b/BaseLib/localization/ita/static_hover_tips.json
@@ -1,0 +1,5 @@
+{
+  "BASELIB-SCRY.title": "Scruta",
+  "BASELIB-SCRY.description": "Guarda le prime [blue]X[/blue] carte del tuo [gold]mazzo di pesca[/gold]. Puoi scartarne quante ne vuoi.",
+  "BASELIB-SCRY.smartDescription": "Guarda {Scry:plural:la prima carta|le prime [blue]{Scry:diff()}[/blue] carte} del tuo [gold]mazzo di pesca[/gold]. Puoi {Scry:plural:scartarla|scartarne quante ne vuoi}."
+}

--- a/BaseLib/localization/jpn/static_hover_tips.json
+++ b/BaseLib/localization/jpn/static_hover_tips.json
@@ -1,8 +1,14 @@
 {
   "BASELIB-PERSIST.title": "持続",
-  "BASELIB-PERSIST.description": "各ターン、このカードは{Persist:cond:>1?最初の[blue]{Persist}[/blue]回|最初の1回}使用時に手札に戻る。",
+  "BASELIB-PERSIST.description": "各ターン、このカードは最初の[blue]X[/blue]回使用時に手札に戻る。",
+  "BASELIB-PERSIST.smartDescription": "各ターン、このカードは{Persist:cond:>1?最初の[blue]{Persist}[/blue]回|最初の1回}使用時に手札に戻る。",
   "BASELIB-EXHAUSTIVE.title": "消耗",
-  "BASELIB-EXHAUSTIVE.description": "このカードは{Exhaustive:cond:>1?[blue]{Exhaustive}[/blue]回|1回}使用すると[gold]廃棄[/gold]される。",
+  "BASELIB-EXHAUSTIVE.description": "このカードは[blue]X[/blue]回使用すると[gold]廃棄[/gold]される。",
+  "BASELIB-EXHAUSTIVE.smartDescription": "このカードは{Exhaustive:cond:>1?[blue]{Exhaustive}[/blue]回|1回}使用すると[gold]廃棄[/gold]される。",
   "BASELIB-REFUND.title": "返還",
-  "BASELIB-REFUND.description": "このカードにエナジーを消費したとき、そのエナジーのうち最大[blue]{Refund}[/blue]が返還される。"
+  "BASELIB-REFUND.description": "このカードにエナジーを消費したとき、そのエナジーのうち最大[blue]X[/blue]が返還される。",
+  "BASELIB-REFUND.smartDescription": "このカードにエナジーを消費したとき、そのエナジーのうち最大[blue]{Refund}[/blue]が返還される。",
+  "BASELIB-SCRY.title": "占術",
+  "BASELIB-SCRY.description": "山札の上からカードを[blue]X[/blue]枚見て、その中から好きなだけ捨ててもよい。",
+  "BASELIB-SCRY.smartDescription": "山札の上から{Scry:plural:カードを1枚|カードを[blue]{Scry:diff()}[/blue]枚}見て、{Scry:plural:それを捨ててもよい|その中から好きなだけ捨ててもよい}。"
 }

--- a/BaseLib/localization/kor/static_hover_tips.json
+++ b/BaseLib/localization/kor/static_hover_tips.json
@@ -1,0 +1,5 @@
+{
+  "BASELIB-SCRY.title": "예지",
+  "BASELIB-SCRY.description": "[gold]뽑을 카드 더미[/gold] 위에서 [blue]X[/blue]장의 카드를 봅니다. 원하는 만큼 버릴 수 있습니다.",
+  "BASELIB-SCRY.smartDescription": "[gold]뽑을 카드 더미[/gold] 위에서 {Scry:cond:>1?[blue]{Scry:diff()}[/blue]장의 카드|카드 1장}를 봅니다. {Scry:cond:>1?원하는 만큼 버릴 수 있습니다|그 카드를 버릴 수 있습니다}."
+}

--- a/BaseLib/localization/rus/static_hover_tips.json
+++ b/BaseLib/localization/rus/static_hover_tips.json
@@ -1,8 +1,14 @@
 {
   "BASELIB-PERSIST.title": "Настойчивость",
-  "BASELIB-PERSIST.description": "Эта карта возвращается в [gold]руку[/gold] при разыгрывании в {Persist:cond:>1?первые [blue]{Persist}[/blue] |первый}{Persist:plural(ru):раз|раза|раз} за ход.",
+  "BASELIB-PERSIST.description": "Эта карта возвращается в [gold]руку[/gold] при разыгрывании в первые [blue]X[/blue] раз за ход.",
+  "BASELIB-PERSIST.smartDescription": "Эта карта возвращается в [gold]руку[/gold] при разыгрывании в {Persist:cond:>1?первые [blue]{Persist}[/blue] |первый}{Persist:plural(ru):раз|раза|раз} за ход.",
   "BASELIB-EXHAUSTIVE.title": "Угасание",
-  "BASELIB-EXHAUSTIVE.description": "Эта карта [gold]сжигается[/gold] после того, как будет разыграна еще {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}{Exhaustive:plural(ru):раз|раза|раз}.",
+  "BASELIB-EXHAUSTIVE.description": "Эта карта [gold]сжигается[/gold] после того, как будет разыграна еще [blue]X[/blue] раз.",
+  "BASELIB-EXHAUSTIVE.smartDescription": "Эта карта [gold]сжигается[/gold] после того, как будет разыграна еще {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}{Exhaustive:plural(ru):раз|раза|раз}.",
   "BASELIB-REFUND.title": "Возврат",
-  "BASELIB-REFUND.description": "Когда вы тратите энергию при разыгрывании этой карты, возвращает до [blue]{Refund}[/blue] {energyPrefix:energyIcons(1)} назад."
+  "BASELIB-REFUND.description": "Когда вы тратите энергию при разыгрывании этой карты, возвращает до [blue]X[/blue] энергии назад.",
+  "BASELIB-REFUND.smartDescription": "Когда вы тратите энергию при разыгрывании этой карты, возвращает до [blue]{Refund}[/blue] {energyPrefix:energyIcons(1)} назад.",
+  "BASELIB-SCRY.title": "Предсказывание карт",
+  "BASELIB-SCRY.description": "Просмотрите верхние [blue]X[/blue] карт [gold]стопки добора[/gold]. Вы можете сбросить любые из них.",
+  "BASELIB-SCRY.smartDescription": "Просмотрите {Scry:plural(ru):верхнюю карту|верхние [blue]{Scry:diff()}[/blue] карты|верхние [blue]{Scry:diff()}[/blue] карт} [gold]стопки добора[/gold]. Вы можете сбросить {Scry:plural(ru):её|любые из них|любые из них}."
 }

--- a/BaseLib/localization/zhs/static_hover_tips.json
+++ b/BaseLib/localization/zhs/static_hover_tips.json
@@ -1,8 +1,14 @@
 ﻿{
   "BASELIB-PERSIST.title": "回旋",
-  "BASELIB-PERSIST.description": "每回合中，这张牌在前 {Persist:cond:>1?[blue]{Persist}[/blue] |}次被打出时都会返回你的手牌。",
+  "BASELIB-PERSIST.description": "每回合中，这张牌在前 [blue]X[/blue] 次被打出时都会返回你的手牌。",
+  "BASELIB-PERSIST.smartDescription": "每回合中，这张牌在前 {Persist:cond:>1?[blue]{Persist}[/blue] |}次被打出时都会返回你的手牌。",
   "BASELIB-EXHAUSTIVE.title": "耐久",
-  "BASELIB-EXHAUSTIVE.description": "这张牌在被使用 {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}次后会[gold]消耗[/gold]。",
+  "BASELIB-EXHAUSTIVE.description": "这张牌在被使用 [blue]X[/blue] 次后会[gold]消耗[/gold]。",
+  "BASELIB-EXHAUSTIVE.smartDescription": "这张牌在被使用 {Exhaustive:cond:>1?[blue]{Exhaustive}[/blue] |}次后会[gold]消耗[/gold]。",
   "BASELIB-REFUND.title": "回能",
-  "BASELIB-REFUND.description": "当此牌花费能量时，返还最多 [blue]{Refund}[/blue] 点能量。"
+  "BASELIB-REFUND.description": "当此牌花费能量时，返还最多 [blue]X[/blue] 点能量。",
+  "BASELIB-REFUND.smartDescription": "当此牌花费能量时，返还最多 [blue]{Refund}[/blue] 点能量。",
+  "BASELIB-SCRY.title": "预见",
+  "BASELIB-SCRY.description": "检视你[gold]抽牌堆[/gold]顶部的 [blue]X[/blue] 张牌。你可以选择丢弃其中的任意张牌。",
+  "BASELIB-SCRY.smartDescription": "检视你[gold]抽牌堆[/gold]顶部的{Scry:cond:>1?[blue]{Scry:diff()}[/blue]张牌|一张牌}。你可以{Scry:cond:>1?选择丢弃其中的任意张牌|选择丢弃这张牌}。"
 }

--- a/Cards/Variables/ScryVar.cs
+++ b/Cards/Variables/ScryVar.cs
@@ -1,4 +1,5 @@
-﻿using BaseLib.Hooks;
+﻿using BaseLib.Extensions;
+using BaseLib.Hooks;
 using MegaCrit.Sts2.Core.Entities.Cards;
 using MegaCrit.Sts2.Core.Entities.Creatures;
 using MegaCrit.Sts2.Core.Localization.DynamicVars;
@@ -10,9 +11,20 @@ namespace BaseLib.Cards.Variables;
 /// Represents a dynamic variable for the "Scry" keyword, responsible for calculating 
 /// and updating the scry value shown on card previews, including active combat modifiers.
 /// </summary>
-/// <param name="baseValue">The base scry amount before modifiers are applied.</param>
-public class ScryVar(decimal baseValue) : DynamicVar("Scry", baseValue)
+public class ScryVar : DynamicVar
 {
+    /// <summary>
+    /// Creates a new scry variable named <c>"Scry"</c> and registers its hover tooltip
+    /// via <see cref="DynamicVarExtensions.WithTooltip{TDynamicVar}"/>, which resolves the
+    /// <c>BASELIB-SCRY</c> localization entries (preferring <c>.smartDescription</c> when available).
+    /// </summary>
+    /// <param name="baseValue">The base scry amount before modifiers are applied.</param>
+    public ScryVar(decimal baseValue) : base("Scry", baseValue)
+    {
+        this.WithTooltip();
+    }
+    
+    
     /// <summary>
     /// Updates the preview value of the scry variable on the card.
     /// Passes the current integer value through global scry modification hooks if enabled.

--- a/Extensions/DynamicVarExtensions.cs
+++ b/Extensions/DynamicVarExtensions.cs
@@ -66,13 +66,18 @@ public static class DynamicVarExtensions
 
         DynamicVarTips[var] = (locVar) =>
         {
-            LocString locString = new(locTable, key + ".title");
-            LocString locString2 = new(locTable, key + ".description");
+            LocString title = new(locTable, key + ".title");
 
-            locString.Add(locVar); //Dynamic var tip should not refer to any variables other than itself...
-            locString2.Add(locVar);
+            var descKey = LocString.Exists(locTable, key + ".smartDescription")
+                ? key + ".smartDescription"
+                : key + ".description";
 
-            return new HoverTip(locString, locString2);
+            LocString description = new(locTable, descKey);
+
+            title.Add(locVar); //Dynamic var tip should not refer to any variables other than itself...
+            description.Add(locVar);
+
+            return new HoverTip(title, description);
         };
 
         return var;

--- a/Utils/BaseLibTip.cs
+++ b/Utils/BaseLibTip.cs
@@ -1,0 +1,31 @@
+﻿using BaseLib.Patches.Content;
+using MegaCrit.Sts2.Core.HoverTips;
+
+namespace BaseLib.Utils;
+
+/// <summary>
+/// Provides <see cref="StaticHoverTip"/> entries for BaseLib's custom keywords, registered
+/// as extensions of the game's hover tip enum via <see cref="CustomEnumAttribute"/>.
+/// These resolve their text from the corresponding <c>BASELIB-*</c> localization entries
+/// and can be attached to cards, relics, or powers like any built-in hover tip.
+/// </summary>
+public static class BaseLibTip
+{
+    /// <summary>
+    /// Hover tip for the <b>Scry</b> keyword: look at the top X cards of your Draw Pile
+    /// and discard any of them. Text from the <c>BASELIB-SCRY</c> localization entries.
+    /// </summary>
+    [CustomEnum] public static StaticHoverTip Scry;
+
+    /// <summary>
+    /// Hover tip for the <b>Refund</b> keyword: when energy is spent on the card,
+    /// up to X of that energy is refunded. Text from the <c>BASELIB-REFUND</c> localization entries.
+    /// </summary>
+    [CustomEnum] public static StaticHoverTip Refund;
+
+    /// <summary>
+    /// Hover tip for the <b>Persist</b> keyword: the card returns to your hand the first
+    /// X times it is played each turn. Text from the <c>BASELIB-PERSIST</c> localization entries.
+    /// </summary>
+    [CustomEnum] public static StaticHoverTip Persist;
+}


### PR DESCRIPTION
resolves issue #348 .

and adds possibility to add static tip without a dynamic var.

(i.e for cards like "Whenever you Scry / Refund / Persist") that dont use an active dynamic var number and only need tip passively