### PR TITLE
Mod config: fix missing characters in some languages

### DIFF
--- a/Config/UI/NConfigButton.cs
+++ b/Config/UI/NConfigButton.cs
@@ -1,4 +1,6 @@
-﻿using Godot;
+﻿using BaseLib.Extensions;
+using Godot;
+using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.Helpers;
 using MegaCrit.Sts2.Core.Nodes.Combat;
@@ -31,21 +33,21 @@ public partial class NConfigButton : NSettingsButton
         _image.SetAnchorsPreset(LayoutPreset.FullRect);
         AddChild(_image);
 
-        var label = new Label
+        var label = new MegaLabel
         {
             Name = "Label",
             HorizontalAlignment = HorizontalAlignment.Center,
             VerticalAlignment = VerticalAlignment.Center,
-            LabelSettings = new LabelSettings
-            {
-                Font = PreloadManager.Cache.GetAsset<FontVariation>("res://themes/kreon_bold_glyph_space_two.tres"),
-                FontSize = 28,
-                FontColor = new Color(0.91f, 0.86f, 0.74f),
-                OutlineSize = 12,
-                OutlineColor = new Color(0.29f, 0.14f, 0.14f)
-            }
+            AutoSizeEnabled = false
         };
+
         label.SetAnchorsPreset(LayoutPreset.FullRect);
+        label.AddThemeFontOverride("font", PreloadManager.Cache.GetAsset<FontVariation>("res://themes/kreon_bold_glyph_space_two.tres"));
+        label.AddThemeFontSizeOverride("font_size", 28);
+        label.AddThemeColorOverride("font_color", new Color(0.91f, 0.86f, 0.74f));
+        label.AddThemeConstantOverride("outline_size", 12);
+        label.AddThemeColorOverride("font_outline_color", new Color(0.29f, 0.14f, 0.14f));
+
         AddChild(label);
 
         var reticleScene = PreloadManager.Cache.GetScene(SceneHelper.GetScenePath("ui/selection_reticle"));

--- a/Config/UI/NConfigLineEdit.cs
+++ b/Config/UI/NConfigLineEdit.cs
@@ -63,6 +63,7 @@ public partial class NConfigLineEdit : NMegaLineEdit, ISelectionReticle
 
     public override void _Ready()
     {
+       base._Ready();
        SetFromProperty();
        if (_config != null) _config.OnConfigReloaded += SetFromProperty;
 

--- a/Config/UI/NModListButton.cs
+++ b/Config/UI/NModListButton.cs
@@ -1,4 +1,5 @@
 ﻿using Godot;
+using MegaCrit.Sts2.addons.mega_text;
 using MegaCrit.Sts2.Core.Assets;
 using MegaCrit.Sts2.Core.ControllerInput;
 using MegaCrit.Sts2.Core.Helpers;
@@ -52,20 +53,23 @@ public partial class NModListButton : NButton
         _backgroundPanel.AddThemeStyleboxOverride("panel", _styleBox);
         AddChild(_backgroundPanel);
 
-        _label = new Label
+        _label = new MegaLabel
         {
             Text = modName,
             HorizontalAlignment = HorizontalAlignment.Left,
             VerticalAlignment = VerticalAlignment.Center,
             TextOverrunBehavior = TextServer.OverrunBehavior.TrimEllipsis,
-            LabelSettings = new LabelSettings {
-                FontSize = 24,
-                Font = PreloadManager.Cache.GetAsset<Font>("res://themes/kreon_regular_glyph_space_one.tres"),
-                FontColor = _textNormal,
-                ShadowSize = 2,
-                ShadowColor = new Color(0f, 0f, 0f, 0.8f)
-            }
+            AutoSizeEnabled = true,
+            MinFontSize = 14,
+            MaxFontSize = 24
         };
+
+        _label.AddThemeFontOverride("font",
+            PreloadManager.Cache.GetAsset<Font>("res://themes/kreon_regular_glyph_space_one.tres"));
+        _label.AddThemeFontSizeOverride("font_size", 24);
+        _label.AddThemeColorOverride("font_color", _textNormal);
+        _label.AddThemeConstantOverride("shadow_outline_size", 2);
+        _label.AddThemeColorOverride("font_shadow_color", new Color(0f, 0f, 0f, 0.8f));
 
         _label.SetAnchorsPreset(LayoutPreset.FullRect);
         _label.OffsetLeft = 24f;
@@ -170,7 +174,8 @@ public partial class NModListButton : NButton
         {
             _styleBox.BgColor = targetBg;
             _styleBox.BorderWidthLeft = targetBorderWidth;
-            _label.LabelSettings.FontColor = targetText;
+            _label.AddThemeColorOverride("font_color", targetText);
+
             return;
         }
 
@@ -178,7 +183,7 @@ public partial class NModListButton : NButton
         _stateTween = CreateTween().SetParallel().SetTrans(Tween.TransitionType.Cubic).SetEase(Tween.EaseType.Out);
 
         _stateTween.TweenProperty(_styleBox, "bg_color", targetBg, 0.1f);
-        _stateTween.TweenProperty(_label.LabelSettings, "font_color", targetText, 0.15f);
+        _stateTween.TweenProperty(_label, "theme_override_colors/font_color", targetText, 0.15f);
         _stateTween.TweenProperty(_styleBox, "border_width_left", targetBorderWidth, 0.2f);
     }
 


### PR DESCRIPTION
Fixes #347 -- not tested on macOS, but tested with a simulated environment (no system font fallbacks, which replicates the issue on Windows), and the fix is the same as the game's code.

Also adds auto-sizing to the buttons in the config screen's list of mods. No change for mods that previously fit (no "..." in the name).