### PR TITLE
fix: stabilize treasure room access on Android v0.107.1

### DIFF
--- a/Abstracts/CustomActModel.cs
+++ b/Abstracts/CustomActModel.cs
@@ -277,17 +277,20 @@ public abstract class CustomActModel : ActModel, ICustomModel, ISceneConversions
     [HarmonyPatch(typeof(NTreasureRoom), nameof(NTreasureRoom._Ready))]
     public static class CustomActTreasureChest
     {
+        // 通过反射读取宝箱房间字段，兼容不同游戏版本的字段具体类型，并避免 Android Mono/Godot 桥接执行直接字段访问。
+        private static readonly FieldInfo? RunState = typeof(NTreasureRoom).Field("_runState");
         private static readonly FieldInfo? ChestNode = typeof(NTreasureRoom).Field("_chestNode");
+        private static readonly FieldInfo? ChestButton = typeof(NTreasureRoom).Field("_chestButton");
 
         [HarmonyPostfix]
         public static void InsertCustomChestVisualNode(NTreasureRoom __instance)
         {
             // validation
-            IRunState? runState = __instance._runState;
+            IRunState? runState = RunState?.GetValue(__instance) as IRunState;
             if (runState?.Act is not CustomActModel customActModel) return;
             if (customActModel.CustomChestScene is null) return;
             Node2D? chestNode = ChestNode?.GetValue(__instance) as Node2D;
-            NButton? chestButton = __instance._chestButton; //Now NTreasureButton, which does still inherit NButton
+            NButton? chestButton = ChestButton?.GetValue(__instance) as NButton; // 字段可能是 NTreasureButton，但仍继承 NButton
             if (chestNode is null || chestButton is null) // should in theory never be the case
             {
                 BaseLibMain.Logger.Warn("References not found. Using normal Chest Visuals instead");


### PR DESCRIPTION
## Summary

This pull request fixes a treasure-room crash when BaseLib 3.4.5 runs on the Android STS2Mobile port with game payload v0.107.1.

## Root Cause

The treasure-room compatibility patch introduced by commit `9a42585` accessed `NTreasureRoom` fields directly:

- `_runState`
- `_chestButton`

During `NTreasureRoom._Ready`, this direct access could trigger an Android Mono/Godot bridge failure:

- `Unreferenced static string to 0`
- Invalid JNI transition-frame reference
- `SIGABRT`

The issue was reproducible on Android but not on PC.

## Fix

The treasure-room postfix now reads `_runState`, `_chestNode`, and `_chestButton` through `FieldInfo.GetValue`.

This avoids direct field access through the Android bridge while preserving compatibility with changed field types such as `NTreasureButton : NButton`. Custom chest visual behavior remains unchanged.

## Validation

- Android STS2Mobile, payload `v0.107.1`: treasure-room entry completed successfully with BaseLib 3.4.5.
- PC STS2, version `v0.107.1`: compatibility confirmed.
- `dotnet build`: passed with 0 errors.
- No new JNI errors, `Unreferenced static string` errors, or `SIGABRT` occurred during Android validation.

## Limitations

Official STS2 beta versions newer than `v0.107.1` have not been validated.

## Android Runtime Context

The Android launcher used by the target environment is:

https://github.com/ModinMobileSTS/Sts2MobileLauncher

The patch is limited to `Abstracts/CustomActModel.cs` and does not change public APIs, save formats, or custom chest behavior.