### PR TITLE
Fix Android treasure-room crash on STS2 v0.107.1

### DIFF
--- a/Abstracts/CustomActModel.cs
+++ b/Abstracts/CustomActModel.cs
@@ -277,17 +277,20 @@ public abstract class CustomActModel : ActModel, ICustomModel, ISceneConversions
     [HarmonyPatch(typeof(NTreasureRoom), nameof(NTreasureRoom._Ready))]
     public static class CustomActTreasureChest
     {
+        // 通过反射读取宝箱房间字段，兼容不同游戏版本的字段具体类型，并避免 Android Mono/Godot 桥接执行直接字段访问。
+        private static readonly FieldInfo? RunState = typeof(NTreasureRoom).Field("_runState");
         private static readonly FieldInfo? ChestNode = typeof(NTreasureRoom).Field("_chestNode");
+        private static readonly FieldInfo? ChestButton = typeof(NTreasureRoom).Field("_chestButton");
 
         [HarmonyPostfix]
         public static void InsertCustomChestVisualNode(NTreasureRoom __instance)
         {
             // validation
-            IRunState? runState = __instance._runState;
+            IRunState? runState = RunState?.GetValue(__instance) as IRunState;
             if (runState?.Act is not CustomActModel customActModel) return;
             if (customActModel.CustomChestScene is null) return;
             Node2D? chestNode = ChestNode?.GetValue(__instance) as Node2D;
-            NButton? chestButton = __instance._chestButton; //Now NTreasureButton, which does still inherit NButton
+            NButton? chestButton = ChestButton?.GetValue(__instance) as NButton; // 字段可能是 NTreasureButton，但仍继承 NButton
             if (chestNode is null || chestButton is null) // should in theory never be the case
             {
                 BaseLibMain.Logger.Warn("References not found. Using normal Chest Visuals instead");


### PR DESCRIPTION
## Summary

Fixes an Android crash when entering a treasure room with a custom act chest on STS2 v0.107.1.

The treasure-room postfix previously accessed `NTreasureRoom` private fields directly. On the Android Mono/Godot bridge, that access could crash before the custom chest visual was inserted. The postfix now reads `_runState` and `_chestButton` through cached `FieldInfo.GetValue` calls, matching the existing reflective access used for `_chestNode` and tolerating field-type changes such as `NTreasureButton` inheriting from `NButton`.

## Validation

- Verified on Android with the ModinMobileSTS/Sts2MobileLauncher launcher on STS2 v0.107.1: entering a treasure room no longer crashes with BaseLib 3.4.5 and the patched DLL.
- Verified compatible on PC STS2 v0.107.1.
- Official STS2 beta builds newer than v0.107.1 have not been tested.