### PR TITLE
Fix canonical cards in restored card rewards

### DIFF
--- a/Patches/Fixes/CardRewardSerializationPatches.cs
+++ b/Patches/Fixes/CardRewardSerializationPatches.cs
@@ -328,7 +328,10 @@ public static class RewardFromSerializableExtPatch
 
                 var rerollOptions = new CardCreationOptions([player.Character.CardPool], source, rarityOdds);
                 if (flags != 0) rerollOptions.WithFlags(flags);
-                return new CardReward(cards, source, player, rerollOptions);
+                var mutableCards = cards
+                    .Select(card => player.RunState.CreateCard(card, player))
+                    .ToList();
+                return new CardReward(mutableCards, source, player, rerollOptions);
             }
 
             BaseLibMain.Logger.Warn(


### PR DESCRIPTION
Restored custom card rewards now convert canonical CardModels through RunState.CreateCard before constructing CardReward. This prevents CanonicalModelException when skipped rewards are serialized on STS2 0.111.