### PR TITLE
feat: Allow ConfigSections to set CollapsedByDefault

### DIFF
--- a/Config/ConfigAttributes.cs
+++ b/Config/ConfigAttributes.cs
@@ -11,6 +11,9 @@ namespace BaseLib.Config;
 public class ConfigSectionAttribute(string name) : Attribute
 {
     public string Name { get; } = name;
+
+    /// <summary>If true, the section starts out collapsed.</summary>
+    public bool CollapsedByDefault { get; set; }
 }
 
 /// <summary>

--- a/Config/SimpleModConfig.cs
+++ b/Config/SimpleModConfig.cs
@@ -331,8 +331,10 @@ public class SimpleModConfig : ModConfig
             var nextRowMember = i < filteredMembers.Count - 1 ? filteredMembers[i + 1] : null;
             
             // Create a new collapsible section if this property starts a new section
-            var sectionName = currentRowMember.GetCustomAttribute<ConfigSectionAttribute>()?.Name;
-            sections.MaybeStartNew(sectionName, CreateCollapsibleSection, targetContainer, ref currentContainer);
+            var sectionAttribute = currentRowMember.GetCustomAttribute<ConfigSectionAttribute>();
+            var sectionName = sectionAttribute?.Name;
+            sections.MaybeStartNew(sectionName, sectionAttribute?.CollapsedByDefault ?? false,
+                CreateCollapsibleSection, targetContainer, ref currentContainer);
 
             // Set up the option row itself
             NConfigOptionRow? newRow;
@@ -675,11 +677,13 @@ public class SimpleModConfig : ModConfig
         public Control? CurrentHeader { get; private set; }
         public string? CurrentSectionName { get; private set; }
 
-        public void MaybeStartNew(string? sectionName, Func<string, bool, bool, NConfigCollapsibleSection> createSection, Control targetContainer, ref Control currentContainer)
+        public void MaybeStartNew(string? sectionName, bool collapsedByDefault,
+            Func<string, bool, bool, NConfigCollapsibleSection> createSection, Control targetContainer,
+            ref Control currentContainer)
         {
             if (sectionName == null || sectionName == CurrentSectionName) return;
 
-            var newSection = createSection(sectionName, false, false);
+            var newSection = createSection(sectionName, false, collapsedByDefault);
             targetContainer.AddChild(newSection);
             currentContainer = newSection.ContentContainer;
 


### PR DESCRIPTION
Adds support for collapsing auto-generated config sections by default.

```csharp
[ConfigSection("Test", CollapsedByDefault = true)]
```

`CollapsedByDefault` defaults to `false`, preserving existing behavior and compatibility. The value is forwarded to the existing collapsible-section UI implementation.

Possible incompat introduced via changing the input params of `SimpleModConfig:MaybeStartNew`, I don't believe this is something a mod would call itself though.

## Testing

Built and tested locally with MintySpire2
```csharp
[ConfigSection("misc", CollapsedByDefault = true)]
    public static bool HideCommonKeywordTooltips { get; set; } = false;
...
```
<img width="1179" height="484" alt="SlayTheSpire2_U5EX2EisVj" src="https://github.com/user-attachments/assets/ad60875b-71db-4457-bf5d-ff7041bd877c" />
