### PR TITLE
Fix CustomResourceCost clone X-cost preservation

### DIFF
--- a/Abstracts/CustomResource.cs
+++ b/Abstracts/CustomResource.cs
@@ -1002,7 +1002,7 @@ public class CustomResourceCost<T> : ICustomResourceCost where T : CustomResourc
             .Select(m => m.Clone())
             .ToList();
         
-        return new CustomResourceCost<T>(newCard, CustomResources<T>.CanonicalCost(newCard), newCard.EnergyCost.CostsX)
+        return new CustomResourceCost<T>(newCard, CustomResources<T>.CanonicalCost(newCard), CostsX)
         {
             _base = _base,
             _capturedXValue = _capturedXValue,


### PR DESCRIPTION
Fixes #386\n\nPreserve the custom resource cost's own X-cost flag when cloning instead of reading the card's energy-cost flag.